### PR TITLE
mariadb optimizer options

### DIFF
--- a/.platform/services.yaml
+++ b/.platform/services.yaml
@@ -2,6 +2,9 @@ db:
     type: mariadb:10.6
     disk: 1500
     configuration:
+      properties:
+        optimizer_switch: "rowid_filter=off"
+        optimizer_use_condition_selectivity: 1
       schemas:
         - main
       endpoints:

--- a/.upsun/config.yaml
+++ b/.upsun/config.yaml
@@ -154,6 +154,9 @@ services:
     db:
         type: mariadb:10.6
         configuration:
+          properties:
+            optimizer_switch: "rowid_filter=off"
+            optimizer_use_condition_selectivity: 1
           schemas:
             - main
           endpoints:


### PR DESCRIPTION
https://experienceleague.adobe.com/en/docs/commerce-operations/installation-guide/prerequisites/database-server/mysql#:~:text=Reindexing%20on%20MariaDB%2010.4%20and%2010.6%20takes%20more%20time%20compared%20to%20previous%20MariaDB%20or%20MySQL%20versions.%20To%20speed%20up%20reindexing%2C%20we%20recommend%20setting%20these%20MariaDB%20configuration%20parameters%3A

