### PR TITLE
Updates patch, updates composer.lock

### DIFF
--- a/.magento.env.yaml
+++ b/.magento.env.yaml
@@ -1,9 +1,9 @@
-system:                                                                                                   
-  variables:                                                                                               
-    ENV_RELATIONSHIPS: "PLATFORM_RELATIONSHIPS"                                                       
-    ENV_ROUTES: "PLATFORM_ROUTES"                                                                     
-    ENV_VARIABLES: "PLATFORM_VARIABLES"                                                               
-    ENV_APPLICATION: "PLATFORM_APPLICATION"                                                           
+system:
+  variables:
+    ENV_RELATIONSHIPS: "PLATFORM_RELATIONSHIPS"
+    ENV_ROUTES: "PLATFORM_ROUTES"
+    ENV_VARIABLES: "PLATFORM_VARIABLES"
+    ENV_APPLICATION: "PLATFORM_APPLICATION"
     ENV_ENVIRONMENT: "PLATFORM_ENVIRONMENT"
 stage:
   global:
@@ -13,7 +13,8 @@ stage:
   build:
     #QUALITY_PATCHES: #this is where you can add patches if needed. https://experienceleague.adobe.com/en/docs/commerce-operations/tools/quality-patches-tool/usage
     QUALITY_PATCHES:
-      - ACSD-58739
+    #  - ACSD-58739
+      - ACP2E-3705
     VERBOSE_COMMANDS: "-vvv"
     SKIP_SCD: false
     SCD_STRATEGY: "compact"

--- a/composer.json
+++ b/composer.json
@@ -8,9 +8,12 @@
     ],
     "config": {
         "allow-plugins": {
+            "composer/installers": true,
             "dealerdirect/phpcodesniffer-composer-installer": true,
             "laminas/laminas-dependency-plugin": true,
-            "magento/*": true
+            "magento/*": true,
+            "php-http/discovery": true,
+            "symfony/flex": true
         },
         "preferred-install": "dist",
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -53,35 +53,36 @@
         },
         {
             "name": "adobe-commerce/adobe-ims-metapackage",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/adobe-commerce/adobe-ims-metapackage-2.2.2.zip",
-                "shasum": "4af10a487a9c7329582a0f0ce8091ac430a87e9b"
+                "url": "https://mirror.mage-os.org/packages/adobe-commerce/adobe-ims-metapackage-2.2.3.zip",
+                "shasum": "ee20906d8278e6ec075836faafd358334d425e7b"
             },
             "require": {
-                "magento/module-admin-adobe-ims": "100.5.2",
-                "magento/module-admin-adobe-ims-two-factor-auth": "1.0.1",
-                "magento/module-adobe-ims": "2.2.1",
-                "magento/module-adobe-ims-api": "2.2.1",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-admin-adobe-ims": "100.5.3",
+                "magento/module-admin-adobe-ims-two-factor-auth": "1.0.2",
+                "magento/module-adobe-ims": "2.2.2",
+                "magento/module-adobe-ims-api": "2.2.2",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "metapackage",
             "description": "Adobe IMS Integration"
         },
         {
             "name": "adobe-commerce/os-extensions-metapackage",
-            "version": "1.0.0",
+            "version": "1.0.1-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/adobe-commerce-os-extensions-metapackage-1.0.0.0.zip",
-                "shasum": "438f5690d41600fa341e629e96ea982882c2be42"
+                "url": "https://mirror.mage-os.org/packages/additional/adobe-commerce-os-extensions-metapackage-1.0.1.0-patch1.zip",
+                "shasum": "6cb1b26ced10786a9936a27459373e1c060dad86"
             },
             "require": {
-                "adobe-commerce/adobe-ims-metapackage": "~2.2.1",
-                "magento/adobe-stock-integration": "~2.1.6",
+                "adobe-commerce/adobe-ims-metapackage": ">=2.2.3@beta <3.0.0",
+                "magento/adobe-stock-integration": ">=2.1.7@beta <3.0.0",
+                "magento/framework": "103.0.*",
                 "magento/payment-services": "^2.0",
-                "paypal/module-braintree": "~4.6.0"
+                "paypal/module-braintree": "~4.6.1"
             },
             "type": "metapackage",
             "description": "Metapackage contains references to extensions bundled with Magento OS"
@@ -182,16 +183,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.342.7",
+            "version": "3.349.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "4d42e384dac1e71107226ed72ed5e8e4d4ee3358"
+                "reference": "b2d4718786398f47626add9c29840fc416175ef2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/4d42e384dac1e71107226ed72ed5e8e4d4ee3358",
-                "reference": "4d42e384dac1e71107226ed72ed5e8e4d4ee3358",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/b2d4718786398f47626add9c29840fc416175ef2",
+                "reference": "b2d4718786398f47626add9c29840fc416175ef2",
                 "shasum": ""
             },
             "require": {
@@ -273,34 +274,34 @@
             "support": {
                 "forum": "https://github.com/aws/aws-sdk-php/discussions",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.342.7"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.349.3"
             },
-            "time": "2025-03-17T18:18:04+00:00"
+            "time": "2025-07-09T18:10:17+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",
-            "version": "2.0.8",
+            "version": "v3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Bacon/BaconQrCode.git",
-                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22"
+                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/8674e51bb65af933a5ffaf1c308a660387c35c22",
-                "reference": "8674e51bb65af933a5ffaf1c308a660387c35c22",
+                "url": "https://api.github.com/repos/Bacon/BaconQrCode/zipball/f9cc1f52b5a463062251d666761178dbdb6b544f",
+                "reference": "f9cc1f52b5a463062251d666761178dbdb6b544f",
                 "shasum": ""
             },
             "require": {
                 "dasprid/enum": "^1.0.3",
                 "ext-iconv": "*",
-                "php": "^7.1 || ^8.0"
+                "php": "^8.1"
             },
             "require-dev": {
-                "phly/keep-a-changelog": "^2.1",
-                "phpunit/phpunit": "^7 | ^8 | ^9",
-                "spatie/phpunit-snapshot-assertions": "^4.2.9",
-                "squizlabs/php_codesniffer": "^3.4"
+                "phly/keep-a-changelog": "^2.12",
+                "phpunit/phpunit": "^10.5.11 || 11.0.4",
+                "spatie/phpunit-snapshot-assertions": "^5.1.5",
+                "squizlabs/php_codesniffer": "^3.9"
             },
             "suggest": {
                 "ext-imagick": "to generate QR code images"
@@ -327,22 +328,22 @@
             "homepage": "https://github.com/Bacon/BaconQrCode",
             "support": {
                 "issues": "https://github.com/Bacon/BaconQrCode/issues",
-                "source": "https://github.com/Bacon/BaconQrCode/tree/2.0.8"
+                "source": "https://github.com/Bacon/BaconQrCode/tree/v3.0.1"
             },
-            "time": "2022-12-07T17:46:57+00:00"
+            "time": "2024-10-01T13:55:55+00:00"
         },
         {
             "name": "braintree/braintree_php",
-            "version": "6.13.0",
+            "version": "6.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/braintree/braintree_php.git",
-                "reference": "c7bdef50c9692f1f9f9bf982e452aec0d137f5ec"
+                "reference": "d94339d1d7ee0ccd3d45727c7b5e36af4c5583a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/c7bdef50c9692f1f9f9bf982e452aec0d137f5ec",
-                "reference": "c7bdef50c9692f1f9f9bf982e452aec0d137f5ec",
+                "url": "https://api.github.com/repos/braintree/braintree_php/zipball/d94339d1d7ee0ccd3d45727c7b5e36af4c5583a8",
+                "reference": "d94339d1d7ee0ccd3d45727c7b5e36af4c5583a8",
                 "shasum": ""
             },
             "require": {
@@ -376,9 +377,9 @@
             "description": "Braintree PHP Client Library",
             "support": {
                 "issues": "https://github.com/braintree/braintree_php/issues",
-                "source": "https://github.com/braintree/braintree_php/tree/6.13.0"
+                "source": "https://github.com/braintree/braintree_php/tree/6.21.0"
             },
-            "time": "2023-08-30T21:46:13+00:00"
+            "time": "2024-10-31T16:08:55+00:00"
         },
         {
             "name": "brick/math",
@@ -706,20 +707,20 @@
         },
         {
             "name": "colinmollenhour/credis",
-            "version": "v1.16.2",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/credis.git",
-                "reference": "db2c0323292e360fdba39bf98c7a405fe3cb05b0"
+                "reference": "f4930b426f6b1238b687a1ffe6ee5af7f835b40a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/db2c0323292e360fdba39bf98c7a405fe3cb05b0",
-                "reference": "db2c0323292e360fdba39bf98c7a405fe3cb05b0",
+                "url": "https://api.github.com/repos/colinmollenhour/credis/zipball/f4930b426f6b1238b687a1ffe6ee5af7f835b40a",
+                "reference": "f4930b426f6b1238b687a1ffe6ee5af7f835b40a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.4.0"
             },
             "suggest": {
                 "ext-redis": "Improved performance for communicating with redis"
@@ -747,27 +748,27 @@
             "homepage": "https://github.com/colinmollenhour/credis",
             "support": {
                 "issues": "https://github.com/colinmollenhour/credis/issues",
-                "source": "https://github.com/colinmollenhour/credis/tree/v1.16.2"
+                "source": "https://github.com/colinmollenhour/credis/tree/v1.17.0"
             },
-            "time": "2024-12-17T02:24:03+00:00"
+            "time": "2025-02-10T18:58:46+00:00"
         },
         {
             "name": "colinmollenhour/php-redis-session-abstract",
-            "version": "v1.5.5",
+            "version": "v2.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/colinmollenhour/php-redis-session-abstract.git",
-                "reference": "5d93866cd53701ef8f866cb41cb5c6d7259d4416"
+                "reference": "defae6e34b0f6ce42e4be4f14f529d8932aea73a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/colinmollenhour/php-redis-session-abstract/zipball/5d93866cd53701ef8f866cb41cb5c6d7259d4416",
-                "reference": "5d93866cd53701ef8f866cb41cb5c6d7259d4416",
+                "url": "https://api.github.com/repos/colinmollenhour/php-redis-session-abstract/zipball/defae6e34b0f6ce42e4be4f14f529d8932aea73a",
+                "reference": "defae6e34b0f6ce42e4be4f14f529d8932aea73a",
                 "shasum": ""
             },
             "require": {
-                "colinmollenhour/credis": "~1.6",
-                "php": "^5.5 || ^7.0 || ^8.0"
+                "colinmollenhour/credis": "~1.17",
+                "php": "^7.4 || ^8.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^9"
@@ -791,22 +792,22 @@
             "homepage": "https://github.com/colinmollenhour/php-redis-session-abstract",
             "support": {
                 "issues": "https://github.com/colinmollenhour/php-redis-session-abstract/issues",
-                "source": "https://github.com/colinmollenhour/php-redis-session-abstract/tree/v1.5.5"
+                "source": "https://github.com/colinmollenhour/php-redis-session-abstract/tree/v2.1.2"
             },
-            "time": "2024-02-03T06:04:45+00:00"
+            "time": "2025-05-05T07:31:11+00:00"
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.6",
+            "version": "1.5.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175"
+                "reference": "d665d22c417056996c59019579f1967dfe5c1e82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/f65c239c970e7f072f067ab78646e9f0b2935175",
-                "reference": "f65c239c970e7f072f067ab78646e9f0b2935175",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/d665d22c417056996c59019579f1967dfe5c1e82",
+                "reference": "d665d22c417056996c59019579f1967dfe5c1e82",
                 "shasum": ""
             },
             "require": {
@@ -853,7 +854,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.6"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.7"
             },
             "funding": [
                 {
@@ -869,20 +870,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-03-06T14:30:56+00:00"
+            "time": "2025-05-26T15:08:54+00:00"
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.6.0",
+            "version": "1.6.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9"
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
-                "reference": "ffe442c5974c44a9343e37a0abcb1cc37319f5b9",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/134b705ddb0025d397d8318a75825fe3c9d1da34",
+                "reference": "134b705ddb0025d397d8318a75825fe3c9d1da34",
                 "shasum": ""
             },
             "require": {
@@ -926,7 +927,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.6.0"
+                "source": "https://github.com/composer/class-map-generator/tree/1.6.1"
             },
             "funding": [
                 {
@@ -942,20 +943,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-05T10:05:34+00:00"
+            "time": "2025-03-24T13:50:44+00:00"
         },
         {
             "name": "composer/composer",
-            "version": "2.8.6",
+            "version": "2.8.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/composer.git",
-                "reference": "937c775a644bd7d2c3dfbb352747488463a6e673"
+                "reference": "53834f587d7ab2527eb237459d7b94d1fb9d4c5a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/composer/zipball/937c775a644bd7d2c3dfbb352747488463a6e673",
-                "reference": "937c775a644bd7d2c3dfbb352747488463a6e673",
+                "url": "https://api.github.com/repos/composer/composer/zipball/53834f587d7ab2527eb237459d7b94d1fb9d4c5a",
+                "reference": "53834f587d7ab2527eb237459d7b94d1fb9d4c5a",
                 "shasum": ""
             },
             "require": {
@@ -966,7 +967,7 @@
                 "composer/semver": "^3.3",
                 "composer/spdx-licenses": "^1.5.7",
                 "composer/xdebug-handler": "^2.0.2 || ^3.0.3",
-                "justinrainbow/json-schema": "^5.3",
+                "justinrainbow/json-schema": "^6.3.1",
                 "php": "^7.2.5 || ^8.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
                 "react/promise": "^2.11 || ^3.2",
@@ -1040,7 +1041,7 @@
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/composer/issues",
                 "security": "https://github.com/composer/composer/security/policy",
-                "source": "https://github.com/composer/composer/tree/2.8.6"
+                "source": "https://github.com/composer/composer/tree/2.8.10"
             },
             "funding": [
                 {
@@ -1056,7 +1057,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-25T12:03:50+00:00"
+            "time": "2025-07-10T17:08:33+00:00"
         },
         {
             "name": "composer/metadata-minifier",
@@ -1289,24 +1290,24 @@
         },
         {
             "name": "composer/spdx-licenses",
-            "version": "1.5.8",
+            "version": "1.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a"
+                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
-                "reference": "560bdcf8deb88ae5d611c80a2de8ea9d0358cc0a",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/edf364cefe8c43501e21e88110aac10b284c3c9f",
+                "reference": "edf364cefe8c43501e21e88110aac10b284c3c9f",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.3.2 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.12.55",
-                "symfony/phpunit-bridge": "^4.2 || ^5"
+                "phpstan/phpstan": "^1.11",
+                "symfony/phpunit-bridge": "^3 || ^7"
             },
             "type": "library",
             "extra": {
@@ -1349,7 +1350,7 @@
             "support": {
                 "irc": "ircs://irc.libera.chat:6697/composer",
                 "issues": "https://github.com/composer/spdx-licenses/issues",
-                "source": "https://github.com/composer/spdx-licenses/tree/1.5.8"
+                "source": "https://github.com/composer/spdx-licenses/tree/1.5.9"
             },
             "funding": [
                 {
@@ -1365,7 +1366,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-20T07:44:33+00:00"
+            "time": "2025-05-12T21:07:07+00:00"
         },
         {
             "name": "composer/xdebug-handler",
@@ -1484,97 +1485,373 @@
             "time": "2024-08-09T14:30:48+00:00"
         },
         {
-            "name": "elasticsearch/elasticsearch",
-            "version": "v7.17.2",
+            "name": "doctrine/lexer",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "2d302233f2bb0926812d82823bb820d405e130fc"
+                "url": "https://github.com/doctrine/lexer.git",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/2d302233f2bb0926812d82823bb820d405e130fc",
-                "reference": "2d302233f2bb0926812d82823bb820d405e130fc",
+                "url": "https://api.github.com/repos/doctrine/lexer/zipball/31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
+                "reference": "31ad66abc0fc9e1a1f2d9bc6a42668d2fbbcd6dd",
                 "shasum": ""
             },
             "require": {
-                "ext-json": ">=1.3.7",
-                "ezimuel/ringphp": "^1.1.2",
-                "php": "^7.3 || ^8.0",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^12",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^10.5",
+                "psalm/plugin-phpunit": "^0.18.3",
+                "vimeo/psalm": "^5.21"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Common\\Lexer\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Guilherme Blanco",
+                    "email": "guilhermeblanco@gmail.com"
+                },
+                {
+                    "name": "Roman Borschel",
+                    "email": "roman@code-factory.org"
+                },
+                {
+                    "name": "Johannes Schmitt",
+                    "email": "schmittjoh@gmail.com"
+                }
+            ],
+            "description": "PHP Doctrine Lexer parser library that can be used in Top-Down, Recursive Descent Parsers.",
+            "homepage": "https://www.doctrine-project.org/projects/lexer.html",
+            "keywords": [
+                "annotations",
+                "docblock",
+                "lexer",
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/lexer/issues",
+                "source": "https://github.com/doctrine/lexer/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Flexer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-02-05T11:56:58+00:00"
+        },
+        {
+            "name": "duosecurity/duo_api_php",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/duosecurity/duo_api_php.git",
+                "reference": "e754a1377d021c38111d06ecafef0778e60c9208"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/duosecurity/duo_api_php/zipball/e754a1377d021c38111d06ecafef0778e60c9208",
+                "reference": "e754a1377d021c38111d06ecafef0778e60c9208",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "dev-master",
+                "phpunit/phpunit": "~9",
+                "squizlabs/php_codesniffer": "2.*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "DuoAPI\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "A PHP implementation of the Duo API.",
+            "homepage": "https://duo.com/",
+            "support": {
+                "email": "support@duosecurity.com",
+                "issues": "https://github.com/duosecurity/duo_api_php/issues",
+                "source": "https://github.com/duosecurity/duo_api_php/tree/1.2.0"
+            },
+            "time": "2025-04-23T14:49:38+00:00"
+        },
+        {
+            "name": "duosecurity/duo_universal_php",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/duosecurity/duo_universal_php.git",
+                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/duosecurity/duo_universal_php/zipball/a2852c46949a2de9ca6da908e4353a81c61b43a3",
+                "reference": "a2852c46949a2de9ca6da908e4353a81c61b43a3",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "firebase/php-jwt": "^6.0",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.0",
+                "squizlabs/php_codesniffer": "3.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Duo\\DuoUniversal\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "A PHP implementation of the Duo Universal SDK.",
+            "homepage": "https://duo.com/",
+            "support": {
+                "email": "support@duosecurity.com",
+                "issues": "https://github.com/duosecurity/duo_universal_php/issues",
+                "source": "https://github.com/duosecurity/duo_universal_php/tree/1.1.0"
+            },
+            "time": "2025-03-05T18:33:28+00:00"
+        },
+        {
+            "name": "egulias/email-validator",
+            "version": "4.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/egulias/EmailValidator.git",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "reference": "d42c8731f0624ad6bdc8d3e5e9a4524f68801cfa",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/lexer": "^2.0 || ^3.0",
+                "php": ">=8.1",
+                "symfony/polyfill-intl-idn": "^1.26"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.2",
+                "vimeo/psalm": "^5.12"
+            },
+            "suggest": {
+                "ext-intl": "PHP Internationalization Libraries are required to use the SpoofChecking validation"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Egulias\\EmailValidator\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eduardo Gulias Davis"
+                }
+            ],
+            "description": "A library for validating emails against several RFCs",
+            "homepage": "https://github.com/egulias/EmailValidator",
+            "keywords": [
+                "email",
+                "emailvalidation",
+                "emailvalidator",
+                "validation",
+                "validator"
+            ],
+            "support": {
+                "issues": "https://github.com/egulias/EmailValidator/issues",
+                "source": "https://github.com/egulias/EmailValidator/tree/4.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/egulias",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "elastic/transport",
+            "version": "v8.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elastic/elastic-transport-php.git",
+                "reference": "1d476af5dc0b74530d59b67d5dd96ee39768d5a4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elastic/elastic-transport-php/zipball/1d476af5dc0b74530d59b67d5dd96ee39768d5a4",
+                "reference": "1d476af5dc0b74530d59b67d5dd96ee39768d5a4",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "open-telemetry/api": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "php-http/discovery": "^1.14",
+                "php-http/httplug": "^2.3",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "nyholm/psr7": "^1.5",
+                "open-telemetry/sdk": "^1.0",
+                "php-http/mock-client": "^1.5",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "symfony/http-client": "^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Elastic\\Transport\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "HTTP transport PHP library for Elastic products",
+            "keywords": [
+                "PSR_17",
+                "elastic",
+                "http",
+                "psr-18",
+                "psr-7",
+                "transport"
+            ],
+            "support": {
+                "issues": "https://github.com/elastic/elastic-transport-php/issues",
+                "source": "https://github.com/elastic/elastic-transport-php/tree/v8.11.0"
+            },
+            "time": "2025-04-02T08:20:33+00:00"
+        },
+        {
+            "name": "elasticsearch/elasticsearch",
+            "version": "v8.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/elastic/elasticsearch-php.git",
+                "reference": "df8ee73046c688ee9ce2d69cb5c54a03ca38cc5c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/df8ee73046c688ee9ce2d69cb5c54a03ca38cc5c",
+                "reference": "df8ee73046c688ee9ce2d69cb5c54a03ca38cc5c",
+                "shasum": ""
+            },
+            "require": {
+                "elastic/transport": "^8.10",
+                "guzzlehttp/guzzle": "^7.0",
+                "php": "^7.4 || ^8.0",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.1 || ^2.0",
                 "psr/log": "^1|^2|^3"
             },
             "require-dev": {
                 "ext-yaml": "*",
                 "ext-zip": "*",
-                "mockery/mockery": "^1.2",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^9.3",
-                "squizlabs/php_codesniffer": "^3.4",
-                "symfony/finder": "~4.0"
-            },
-            "suggest": {
-                "ext-curl": "*",
-                "monolog/monolog": "Allows for client-level logging and tracing"
+                "mockery/mockery": "^1.5",
+                "nyholm/psr7": "^1.5",
+                "php-http/mock-client": "^1.5",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^9.5",
+                "psr/http-factory": "^1.0",
+                "symfony/finder": "~4.0",
+                "symfony/http-client": "^5.0|^6.0|^7.0"
             },
             "type": "library",
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
-                    "Elasticsearch\\": "src/Elasticsearch/"
+                    "Elastic\\Elasticsearch\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "Apache-2.0",
-                "LGPL-2.1-only"
-            ],
-            "authors": [
-                {
-                    "name": "Zachary Tong"
-                },
-                {
-                    "name": "Enrico Zimuel"
-                }
+                "MIT"
             ],
             "description": "PHP Client for Elasticsearch",
             "keywords": [
                 "client",
+                "elastic",
                 "elasticsearch",
                 "search"
             ],
             "support": {
                 "issues": "https://github.com/elastic/elasticsearch-php/issues",
-                "source": "https://github.com/elastic/elasticsearch-php/tree/v7.17.2"
+                "source": "https://github.com/elastic/elasticsearch-php/tree/v8.18.0"
             },
-            "time": "2023-04-21T15:31:12+00:00"
+            "time": "2025-05-02T10:38:56+00:00"
         },
         {
             "name": "endroid/qr-code",
-            "version": "4.8.5",
+            "version": "6.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/endroid/qr-code.git",
-                "reference": "0db25b506a8411a5e1644ebaa67123a6eb7b6a77"
+                "reference": "21e888e8597440b2205e2e5c484b6c8e556bcd1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/endroid/qr-code/zipball/0db25b506a8411a5e1644ebaa67123a6eb7b6a77",
-                "reference": "0db25b506a8411a5e1644ebaa67123a6eb7b6a77",
+                "url": "https://api.github.com/repos/endroid/qr-code/zipball/21e888e8597440b2205e2e5c484b6c8e556bcd1a",
+                "reference": "21e888e8597440b2205e2e5c484b6c8e556bcd1a",
                 "shasum": ""
             },
             "require": {
-                "bacon/bacon-qr-code": "^2.0.5",
-                "php": "^8.1"
-            },
-            "conflict": {
-                "khanamiryan/qrcode-detector-decoder": "^1.0.6"
+                "bacon/bacon-qr-code": "^3.0",
+                "php": "^8.2"
             },
             "require-dev": {
-                "endroid/quality": "dev-master",
+                "endroid/quality": "dev-main",
                 "ext-gd": "*",
-                "khanamiryan/qrcode-detector-decoder": "^1.0.4||^2.0.2",
+                "khanamiryan/qrcode-detector-decoder": "^2.0.2",
                 "setasign/fpdf": "^1.8.2"
             },
             "suggest": {
@@ -1586,7 +1863,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.x-dev"
+                    "dev-main": "6.x-dev"
                 }
             },
             "autoload": {
@@ -1615,7 +1892,7 @@
             ],
             "support": {
                 "issues": "https://github.com/endroid/qr-code/issues",
-                "source": "https://github.com/endroid/qr-code/tree/4.8.5"
+                "source": "https://github.com/endroid/qr-code/tree/6.0.9"
             },
             "funding": [
                 {
@@ -1623,7 +1900,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-09-29T14:03:20+00:00"
+            "time": "2025-07-13T19:59:45+00:00"
         },
         {
             "name": "ezimuel/guzzlestreams",
@@ -1798,16 +2075,16 @@
         },
         {
             "name": "fastly/magento2",
-            "version": "1.2.226",
+            "version": "1.2.230",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fastly/fastly-magento2.git",
-                "reference": "0584eb0ba5d4d551dbd76e5e2bb25be8e5399cf5"
+                "reference": "ee92294d0a586fa009f680558a1ffd491f1b5006"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fastly/fastly-magento2/zipball/0584eb0ba5d4d551dbd76e5e2bb25be8e5399cf5",
-                "reference": "0584eb0ba5d4d551dbd76e5e2bb25be8e5399cf5",
+                "url": "https://api.github.com/repos/fastly/fastly-magento2/zipball/ee92294d0a586fa009f680558a1ffd491f1b5006",
+                "reference": "ee92294d0a586fa009f680558a1ffd491f1b5006",
                 "shasum": ""
             },
             "require": {
@@ -1836,22 +2113,22 @@
             "description": "Fastly CDN Module for Magento 2.4.x",
             "support": {
                 "issues": "https://github.com/fastly/fastly-magento2/issues",
-                "source": "https://github.com/fastly/fastly-magento2/tree/1.2.226"
+                "source": "https://github.com/fastly/fastly-magento2/tree/1.2.230"
             },
-            "time": "2025-02-14T15:31:20+00:00"
+            "time": "2025-07-10T05:41:35+00:00"
         },
         {
             "name": "firebase/php-jwt",
-            "version": "v6.11.0",
+            "version": "v6.11.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/firebase/php-jwt.git",
-                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712"
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/8f718f4dfc9c5d5f0c994cdfd103921b43592712",
-                "reference": "8f718f4dfc9c5d5f0c994cdfd103921b43592712",
+                "url": "https://api.github.com/repos/firebase/php-jwt/zipball/d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
+                "reference": "d1e91ecf8c598d073d0995afa8cd5c75c6e19e66",
                 "shasum": ""
             },
             "require": {
@@ -1899,9 +2176,9 @@
             ],
             "support": {
                 "issues": "https://github.com/firebase/php-jwt/issues",
-                "source": "https://github.com/firebase/php-jwt/tree/v6.11.0"
+                "source": "https://github.com/firebase/php-jwt/tree/v6.11.1"
             },
-            "time": "2025-01-23T05:11:06+00:00"
+            "time": "2025-04-09T20:32:01+00:00"
         },
         {
             "name": "friendsofphp/proxy-manager-lts",
@@ -1986,58 +2263,6 @@
             "time": "2024-03-20T12:50:41+00:00"
         },
         {
-            "name": "google/recaptcha",
-            "version": "1.3.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/google/recaptcha.git",
-                "reference": "d59a801e98a4e9174814a6d71bbc268dff1202df"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/google/recaptcha/zipball/d59a801e98a4e9174814a6d71bbc268dff1202df",
-                "reference": "d59a801e98a4e9174814a6d71bbc268dff1202df",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8"
-            },
-            "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.14",
-                "php-coveralls/php-coveralls": "^2.5",
-                "phpunit/phpunit": "^10"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "ReCaptcha\\": "src/ReCaptcha"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Client library for reCAPTCHA, a free service that protects websites from spam and abuse.",
-            "homepage": "https://www.google.com/recaptcha/",
-            "keywords": [
-                "Abuse",
-                "captcha",
-                "recaptcha",
-                "spam"
-            ],
-            "support": {
-                "forum": "https://groups.google.com/forum/#!forum/recaptcha",
-                "issues": "https://github.com/google/recaptcha/issues",
-                "source": "https://github.com/google/recaptcha"
-            },
-            "time": "2023-02-18T17:41:46+00:00"
-        },
-        {
             "name": "graylog2/gelf-php",
             "version": "2.0.2",
             "source": {
@@ -2095,16 +2320,16 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.9.2",
+            "version": "7.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b"
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d281ed313b989f213357e3be1a179f02196ac99b",
-                "reference": "d281ed313b989f213357e3be1a179f02196ac99b",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
+                "reference": "7b2f29fe81dc4da0ca0ea7d42107a0845946ea77",
                 "shasum": ""
             },
             "require": {
@@ -2201,7 +2426,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.9.2"
+                "source": "https://github.com/guzzle/guzzle/tree/7.9.3"
             },
             "funding": [
                 {
@@ -2217,20 +2442,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-24T11:22:20+00:00"
+            "time": "2025-03-27T13:37:11+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.0.4",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455"
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
-                "reference": "f9c436286ab2892c7db7be8c8da4ef61ccf7b455",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/7c69f28996b0a6920945dd20b3857e499d9ca96c",
+                "reference": "7c69f28996b0a6920945dd20b3857e499d9ca96c",
                 "shasum": ""
             },
             "require": {
@@ -2284,7 +2509,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.0.4"
+                "source": "https://github.com/guzzle/promises/tree/2.2.0"
             },
             "funding": [
                 {
@@ -2300,20 +2525,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-10-17T10:06:22+00:00"
+            "time": "2025-03-27T13:27:01+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.7.0",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201"
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
-                "reference": "a70f5c95fb43bc83f07c9c948baa0dc1829bf201",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/c2270caaabe631b3b44c85f99e5a04bbb8060d16",
+                "reference": "c2270caaabe631b3b44c85f99e5a04bbb8060d16",
                 "shasum": ""
             },
             "require": {
@@ -2400,7 +2625,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.7.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.7.1"
             },
             "funding": [
                 {
@@ -2416,35 +2641,36 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-07-18T11:15:46+00:00"
+            "time": "2025-03-27T12:30:47+00:00"
         },
         {
             "name": "illuminate/collections",
-            "version": "v11.44.2",
+            "version": "v12.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/collections.git",
-                "reference": "f2f537dfb2a142791d37478f34c920b44a45cea9"
+                "reference": "25cf57b8c994eb8193c2a8bdf6e9eb99d343a8b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/collections/zipball/f2f537dfb2a142791d37478f34c920b44a45cea9",
-                "reference": "f2f537dfb2a142791d37478f34c920b44a45cea9",
+                "url": "https://api.github.com/repos/illuminate/collections/zipball/25cf57b8c994eb8193c2a8bdf6e9eb99d343a8b7",
+                "reference": "25cf57b8c994eb8193c2a8bdf6e9eb99d343a8b7",
                 "shasum": ""
             },
             "require": {
-                "illuminate/conditionable": "^11.0",
-                "illuminate/contracts": "^11.0",
-                "illuminate/macroable": "^11.0",
+                "illuminate/conditionable": "^12.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/macroable": "^12.0",
                 "php": "^8.2"
             },
             "suggest": {
-                "symfony/var-dumper": "Required to use the dump method (^7.0)."
+                "illuminate/http": "Required to convert collections to API resources (^12.0).",
+                "symfony/var-dumper": "Required to use the dump method (^7.2)."
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -2472,29 +2698,29 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-03-06T14:02:47+00:00"
+            "time": "2025-07-01T16:49:44+00:00"
         },
         {
             "name": "illuminate/conditionable",
-            "version": "v11.44.2",
+            "version": "v12.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/conditionable.git",
-                "reference": "911df1bda950a3b799cf80671764e34eede131c6"
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/911df1bda950a3b799cf80671764e34eede131c6",
-                "reference": "911df1bda950a3b799cf80671764e34eede131c6",
+                "url": "https://api.github.com/repos/illuminate/conditionable/zipball/ec677967c1f2faf90b8428919124d2184a4c9b49",
+                "reference": "ec677967c1f2faf90b8428919124d2184a4c9b49",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.0.2"
+                "php": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -2518,31 +2744,31 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-21T16:28:56+00:00"
+            "time": "2025-05-13T15:08:45+00:00"
         },
         {
             "name": "illuminate/config",
-            "version": "v11.44.2",
+            "version": "v12.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/config.git",
-                "reference": "64daa8d520cd76e505a82460a672692c56a07be8"
+                "reference": "06c8e1dc8fc890562eab7609d6454aa98f49da5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/config/zipball/64daa8d520cd76e505a82460a672692c56a07be8",
-                "reference": "64daa8d520cd76e505a82460a672692c56a07be8",
+                "url": "https://api.github.com/repos/illuminate/config/zipball/06c8e1dc8fc890562eab7609d6454aa98f49da5c",
+                "reference": "06c8e1dc8fc890562eab7609d6454aa98f49da5c",
                 "shasum": ""
             },
             "require": {
-                "illuminate/collections": "^11.0",
-                "illuminate/contracts": "^11.0",
+                "illuminate/collections": "^12.0",
+                "illuminate/contracts": "^12.0",
                 "php": "^8.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -2566,20 +2792,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-11-14T17:17:02+00:00"
+            "time": "2025-07-02T22:34:43+00:00"
         },
         {
             "name": "illuminate/contracts",
-            "version": "v11.44.2",
+            "version": "v12.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/contracts.git",
-                "reference": "b350a3cd8450846325cb49e1cbc1293598b18898"
+                "reference": "e0fe87237da006e7d26e1167b6241786d68923e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/contracts/zipball/b350a3cd8450846325cb49e1cbc1293598b18898",
-                "reference": "b350a3cd8450846325cb49e1cbc1293598b18898",
+                "url": "https://api.github.com/repos/illuminate/contracts/zipball/e0fe87237da006e7d26e1167b6241786d68923e8",
+                "reference": "e0fe87237da006e7d26e1167b6241786d68923e8",
                 "shasum": ""
             },
             "require": {
@@ -2590,7 +2816,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -2614,20 +2840,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2025-02-10T14:20:57+00:00"
+            "time": "2025-07-01T15:59:53+00:00"
         },
         {
             "name": "illuminate/macroable",
-            "version": "v11.44.2",
+            "version": "v12.20.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/illuminate/macroable.git",
-                "reference": "e1cb9e51b9ed5d3c9bc1ab431d0a52fe42a990ed"
+                "reference": "e862e5648ee34004fa56046b746f490dfa86c613"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e1cb9e51b9ed5d3c9bc1ab431d0a52fe42a990ed",
-                "reference": "e1cb9e51b9ed5d3c9bc1ab431d0a52fe42a990ed",
+                "url": "https://api.github.com/repos/illuminate/macroable/zipball/e862e5648ee34004fa56046b746f490dfa86c613",
+                "reference": "e862e5648ee34004fa56046b746f490dfa86c613",
                 "shasum": ""
             },
             "require": {
@@ -2636,7 +2862,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "11.x-dev"
+                    "dev-master": "12.x-dev"
                 }
             },
             "autoload": {
@@ -2660,34 +2886,44 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2024-06-28T20:10:30+00:00"
+            "time": "2024-07-23T16:31:01+00:00"
         },
         {
             "name": "justinrainbow/json-schema",
-            "version": "5.3.0",
+            "version": "6.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/jsonrainbow/json-schema.git",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8"
+                "reference": "ce1fd2d47799bb60668643bc6220f6278a4c1d02"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
-                "reference": "feb2ca6dd1cebdaf1ed60a4c8de2e53ce11c4fd8",
+                "url": "https://api.github.com/repos/jsonrainbow/json-schema/zipball/ce1fd2d47799bb60668643bc6220f6278a4c1d02",
+                "reference": "ce1fd2d47799bb60668643bc6220f6278a4c1d02",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "ext-json": "*",
+                "marc-mabe/php-enum": "^4.0",
+                "php": "^7.2 || ^8.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "~2.2.20||~2.15.1",
+                "friendsofphp/php-cs-fixer": "3.3.0",
                 "json-schema/json-schema-test-suite": "1.2.0",
-                "phpunit/phpunit": "^4.8.35"
+                "marc-mabe/php-enum-phpstan": "^2.0",
+                "phpspec/prophecy": "^1.19",
+                "phpstan/phpstan": "^1.12",
+                "phpunit/phpunit": "^8.5"
             },
             "bin": [
                 "bin/validate-json"
             ],
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "JsonSchema\\": "src/JsonSchema/"
@@ -2716,16 +2952,16 @@
                 }
             ],
             "description": "A library to validate a json schema.",
-            "homepage": "https://github.com/justinrainbow/json-schema",
+            "homepage": "https://github.com/jsonrainbow/json-schema",
             "keywords": [
                 "json",
                 "schema"
             ],
             "support": {
                 "issues": "https://github.com/jsonrainbow/json-schema/issues",
-                "source": "https://github.com/jsonrainbow/json-schema/tree/5.3.0"
+                "source": "https://github.com/jsonrainbow/json-schema/tree/6.4.2"
             },
-            "time": "2024-07-06T21:00:26+00:00"
+            "time": "2025-06-03T18:27:04+00:00"
         },
         {
             "name": "laminas/laminas-captcha",
@@ -2927,141 +3163,6 @@
             "time": "2024-12-05T14:32:05+00:00"
         },
         {
-            "name": "laminas/laminas-crypt",
-            "version": "3.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-crypt.git",
-                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-crypt/zipball/ceab630494fc7a0d82ec39ad63947ef889a21be7",
-                "reference": "ceab630494fc7a0d82ec39ad63947ef889a21be7",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "laminas/laminas-math": "^3.4",
-                "laminas/laminas-stdlib": "^3.8",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/container": "^1.1"
-            },
-            "conflict": {
-                "zendframework/zend-crypt": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "suggest": {
-                "ext-openssl": "Required for most features of Laminas\\Crypt"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Crypt\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Strong cryptography tools and password hashing",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "crypt",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-crypt/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-crypt/issues",
-                "rss": "https://github.com/laminas/laminas-crypt/releases.atom",
-                "source": "https://github.com/laminas/laminas-crypt"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-07-15T09:11:42+00:00"
-        },
-        {
-            "name": "laminas/laminas-db",
-            "version": "2.20.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-db.git",
-                "reference": "207b9ee70a8b518913c1fad688d7a64fe89a8b91"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-db/zipball/207b9ee70a8b518913c1fad688d7a64fe89a8b91",
-                "reference": "207b9ee70a8b518913c1fad688d7a64fe89a8b91",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^3.7.1",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-db": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "^2.4.0",
-                "laminas/laminas-eventmanager": "^3.6.0",
-                "laminas/laminas-hydrator": "^4.7",
-                "laminas/laminas-servicemanager": "^3.19.0",
-                "phpunit/phpunit": "^9.5.25"
-            },
-            "suggest": {
-                "laminas/laminas-eventmanager": "Laminas\\EventManager component",
-                "laminas/laminas-hydrator": "(^3.2 || ^4.3) Laminas\\Hydrator component for using HydratingResultSets",
-                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Db",
-                    "config-provider": "Laminas\\Db\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Db\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "db",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-db/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-db/issues",
-                "rss": "https://github.com/laminas/laminas-db/releases.atom",
-                "source": "https://github.com/laminas/laminas-db"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "time": "2024-04-02T01:04:56+00:00"
-        },
-        {
             "name": "laminas/laminas-di",
             "version": "3.15.0",
             "source": {
@@ -3141,16 +3242,16 @@
         },
         {
             "name": "laminas/laminas-escaper",
-            "version": "2.16.0",
+            "version": "2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-escaper.git",
-                "reference": "9cf1f5317ca65b4fd5c6a3c2855e24a187b288c8"
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/9cf1f5317ca65b4fd5c6a3c2855e24a187b288c8",
-                "reference": "9cf1f5317ca65b4fd5c6a3c2855e24a187b288c8",
+                "url": "https://api.github.com/repos/laminas/laminas-escaper/zipball/df1ef9503299a8e3920079a16263b578eaf7c3ba",
+                "reference": "df1ef9503299a8e3920079a16263b578eaf7c3ba",
                 "shasum": ""
             },
             "require": {
@@ -3198,7 +3299,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-02-17T12:40:19+00:00"
+            "time": "2025-05-06T19:29:36+00:00"
         },
         {
             "name": "laminas/laminas-eventmanager",
@@ -3270,20 +3371,21 @@
         },
         {
             "name": "laminas/laminas-feed",
-            "version": "2.23.0",
+            "version": "2.24.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-feed.git",
-                "reference": "23807e692b3174750b426143bd93572b71b6739a"
+                "reference": "3df6dfe39ce1f53df64eb12f9fcf9bb29074cd50"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/23807e692b3174750b426143bd93572b71b6739a",
-                "reference": "23807e692b3174750b426143bd93572b71b6739a",
+                "url": "https://api.github.com/repos/laminas/laminas-feed/zipball/3df6dfe39ce1f53df64eb12f9fcf9bb29074cd50",
+                "reference": "3df6dfe39ce1f53df64eb12f9fcf9bb29074cd50",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
+                "ext-filter": "*",
                 "ext-libxml": "*",
                 "laminas/laminas-escaper": "^2.9",
                 "laminas/laminas-stdlib": "^3.6",
@@ -3346,89 +3448,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-09T10:53:30+00:00"
-        },
-        {
-            "name": "laminas/laminas-file",
-            "version": "2.13.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-file.git",
-                "reference": "09ef45c63875c226093efe893ada3ebe656072ff"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-file/zipball/09ef45c63875c226093efe893ada3ebe656072ff",
-                "reference": "09ef45c63875c226093efe893ada3ebe656072ff",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^2.7.7 || ^3.15.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-file": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~1.0.0",
-                "laminas/laminas-filter": "^2.23.2",
-                "laminas/laminas-i18n": "^2.7.4",
-                "laminas/laminas-progressbar": "^2.5.2",
-                "laminas/laminas-servicemanager": "^2.7.8 || ^3.3",
-                "laminas/laminas-session": "^2.8",
-                "laminas/laminas-validator": "^2.10.1",
-                "phpunit/phpunit": "^9.5.10"
-            },
-            "suggest": {
-                "laminas/laminas-filter": "Laminas\\Filter component",
-                "laminas/laminas-i18n": "Laminas\\I18n component",
-                "laminas/laminas-validator": "Laminas\\Validator component"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\File\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Locate PHP classfiles",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "file",
-                "laminas"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-file/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-file/issues",
-                "rss": "https://github.com/laminas/laminas-file/releases.atom",
-                "source": "https://github.com/laminas/laminas-file"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-12-05T15:04:21+00:00"
+            "time": "2025-06-25T12:37:12+00:00"
         },
         {
             "name": "laminas/laminas-filter",
-            "version": "2.40.0",
+            "version": "2.41.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-filter.git",
-                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b"
+                "reference": "eaa00111231bf6669826ae84d3abe85b94477585"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/9b32ba7c45a302ed349bf42061308e854d56e75b",
-                "reference": "9b32ba7c45a302ed349bf42061308e854d56e75b",
+                "url": "https://api.github.com/repos/laminas/laminas-filter/zipball/eaa00111231bf6669826ae84d3abe85b94477585",
+                "reference": "eaa00111231bf6669826ae84d3abe85b94477585",
                 "shasum": ""
             },
             "require": {
@@ -3494,20 +3527,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2025-01-06T21:36:57+00:00"
+            "time": "2025-05-05T02:02:31+00:00"
         },
         {
             "name": "laminas/laminas-http",
-            "version": "2.21.0",
+            "version": "2.22.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-http.git",
-                "reference": "a9867e4d1cda3dbad208903239c83a3d670cce10"
+                "reference": "5052177fb8176e00b0d4b89108648f557be072b7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/a9867e4d1cda3dbad208903239c83a3d670cce10",
-                "reference": "a9867e4d1cda3dbad208903239c83a3d670cce10",
+                "url": "https://api.github.com/repos/laminas/laminas-http/zipball/5052177fb8176e00b0d4b89108648f557be072b7",
+                "reference": "5052177fb8176e00b0d4b89108648f557be072b7",
                 "shasum": ""
             },
             "require": {
@@ -3522,8 +3555,8 @@
             },
             "require-dev": {
                 "ext-curl": "*",
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "^9.6.21"
+                "laminas/laminas-coding-standard": "^3.0.1",
+                "phpunit/phpunit": "^10.5.38"
             },
             "suggest": {
                 "paragonie/certainty": "For automated management of cacert.pem"
@@ -3559,20 +3592,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-12-04T09:17:39+00:00"
+            "time": "2025-05-06T08:24:40+00:00"
         },
         {
             "name": "laminas/laminas-i18n",
-            "version": "2.29.0",
+            "version": "2.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-i18n.git",
-                "reference": "9aa7ef6073556e9b4cfd8d9a0cb8e41cd3883454"
+                "reference": "397907ee061e147939364df9d6c485ac1e0fed87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/9aa7ef6073556e9b4cfd8d9a0cb8e41cd3883454",
-                "reference": "9aa7ef6073556e9b4cfd8d9a0cb8e41cd3883454",
+                "url": "https://api.github.com/repos/laminas/laminas-i18n/zipball/397907ee061e147939364df9d6c485ac1e0fed87",
+                "reference": "397907ee061e147939364df9d6c485ac1e0fed87",
                 "shasum": ""
             },
             "require": {
@@ -3587,18 +3620,18 @@
                 "zendframework/zend-i18n": "*"
             },
             "require-dev": {
-                "laminas/laminas-cache": "^3.12.1",
-                "laminas/laminas-cache-storage-adapter-memory": "^2.3.0",
-                "laminas/laminas-cache-storage-deprecated-factory": "^1.2",
+                "laminas/laminas-cache": "^3.13.0",
+                "laminas/laminas-cache-storage-adapter-memory": "^2.4.0",
+                "laminas/laminas-cache-storage-deprecated-factory": "^1.3",
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-config": "^3.9.0",
-                "laminas/laminas-eventmanager": "^3.13",
-                "laminas/laminas-filter": "^2.34",
-                "laminas/laminas-validator": "^2.49",
-                "laminas/laminas-view": "^2.34",
-                "phpunit/phpunit": "^10.5.11",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.22.2"
+                "laminas/laminas-config": "^3.10.1",
+                "laminas/laminas-eventmanager": "^3.14.0",
+                "laminas/laminas-filter": "^2.40",
+                "laminas/laminas-validator": "^2.64.2",
+                "laminas/laminas-view": "^2.36",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.0"
             },
             "suggest": {
                 "laminas/laminas-cache": "You should install this package to cache the translations",
@@ -3645,7 +3678,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-10-11T09:44:53+00:00"
+            "time": "2025-04-15T09:07:02+00:00"
         },
         {
             "name": "laminas/laminas-json",
@@ -3765,212 +3798,6 @@
             ],
             "abandoned": true,
             "time": "2024-12-05T14:43:32+00:00"
-        },
-        {
-            "name": "laminas/laminas-mail",
-            "version": "2.25.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-mail.git",
-                "reference": "110e04497395123998220e244cceecb167cc6dda"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mail/zipball/110e04497395123998220e244cceecb167cc6dda",
-                "reference": "110e04497395123998220e244cceecb167cc6dda",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "laminas/laminas-loader": "^2.9.0",
-                "laminas/laminas-mime": "^2.11.0",
-                "laminas/laminas-stdlib": "^3.17.0",
-                "laminas/laminas-validator": "^2.31.0",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "symfony/polyfill-intl-idn": "^1.27.0",
-                "symfony/polyfill-mbstring": "^1.27.0",
-                "webmozart/assert": "^1.11.0"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-db": "^2.18",
-                "laminas/laminas-servicemanager": "^3.22.1",
-                "phpunit/phpunit": "^10.4.2",
-                "psalm/plugin-phpunit": "^0.18.4",
-                "symfony/process": "^6.3.4",
-                "vimeo/psalm": "^5.15"
-            },
-            "suggest": {
-                "laminas/laminas-servicemanager": "^3.21 when using SMTP to deliver messages"
-            },
-            "type": "library",
-            "extra": {
-                "laminas": {
-                    "component": "Laminas\\Mail",
-                    "config-provider": "Laminas\\Mail\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Mail\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "mail"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-mail/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-mail/issues",
-                "rss": "https://github.com/laminas/laminas-mail/releases.atom",
-                "source": "https://github.com/laminas/laminas-mail"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": "symfony/mailer",
-            "time": "2023-11-02T10:32:34+00:00"
-        },
-        {
-            "name": "laminas/laminas-math",
-            "version": "3.8.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-math.git",
-                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-math/zipball/a9e54f68accf5f8a3e66dd01fc6b32180e520018",
-                "reference": "a9e54f68accf5f8a3e66dd01fc6b32180e520018",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zend-math": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "phpunit/phpunit": "~9.5.25"
-            },
-            "suggest": {
-                "ext-bcmath": "If using the bcmath functionality",
-                "ext-gmp": "If using the gmp functionality"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Math\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create cryptographically secure pseudo-random numbers, and manage big integers",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "math"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-math/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-math/issues",
-                "rss": "https://github.com/laminas/laminas-math/releases.atom",
-                "source": "https://github.com/laminas/laminas-math"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-12-05T13:49:56+00:00"
-        },
-        {
-            "name": "laminas/laminas-mime",
-            "version": "2.12.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-mime.git",
-                "reference": "08cc544778829b7d68d27a097885bd6e7130135e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-mime/zipball/08cc544778829b7d68d27a097885bd6e7130135e",
-                "reference": "08cc544778829b7d68d27a097885bd6e7130135e",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-stdlib": "^2.7 || ^3.0",
-                "php": "~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0"
-            },
-            "conflict": {
-                "zendframework/zend-mime": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.4.0",
-                "laminas/laminas-mail": "^2.19.0",
-                "phpunit/phpunit": "~9.5.25"
-            },
-            "suggest": {
-                "laminas/laminas-mail": "Laminas\\Mail component"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\Mime\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create and parse MIME messages and parts",
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "mime"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-mime/",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-mime/issues",
-                "rss": "https://github.com/laminas/laminas-mime/releases.atom",
-                "source": "https://github.com/laminas/laminas-mime"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": "symfony/mime",
-            "time": "2023-11-02T16:47:19+00:00"
         },
         {
             "name": "laminas/laminas-modulemanager",
@@ -4123,69 +3950,6 @@
                 }
             ],
             "time": "2024-11-18T00:14:29+00:00"
-        },
-        {
-            "name": "laminas/laminas-oauth",
-            "version": "2.7.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/laminas/laminas-oauth.git",
-                "reference": "5182456ec570c6dd6c04003349ab65d9bd553850"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-oauth/zipball/5182456ec570c6dd6c04003349ab65d9bd553850",
-                "reference": "5182456ec570c6dd6c04003349ab65d9bd553850",
-                "shasum": ""
-            },
-            "require": {
-                "laminas/laminas-config": "^3.7",
-                "laminas/laminas-crypt": "^3.6.0",
-                "laminas/laminas-http": "^2.15",
-                "laminas/laminas-i18n": "^2.13.0",
-                "laminas/laminas-loader": "^2.8",
-                "laminas/laminas-math": "^3.5",
-                "laminas/laminas-stdlib": "^3.10",
-                "laminas/laminas-uri": "^2.9",
-                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
-            },
-            "conflict": {
-                "zendframework/zendoauth": "*"
-            },
-            "require-dev": {
-                "laminas/laminas-coding-standard": "~2.5.0",
-                "phpunit/phpunit": "^9.6.20"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Laminas\\OAuth\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "homepage": "https://laminas.dev",
-            "keywords": [
-                "laminas",
-                "oauth"
-            ],
-            "support": {
-                "chat": "https://laminas.dev/chat",
-                "forum": "https://discourse.laminas.dev",
-                "issues": "https://github.com/laminas/laminas-oauth/issues",
-                "rss": "https://github.com/laminas/laminas-oauth/releases.atom",
-                "source": "https://github.com/laminas/laminas-oauth"
-            },
-            "funding": [
-                {
-                    "url": "https://funding.communitybridge.org/projects/laminas-project",
-                    "type": "community_bridge"
-                }
-            ],
-            "abandoned": true,
-            "time": "2024-10-23T13:17:27+00:00"
         },
         {
             "name": "laminas/laminas-permissions-acl",
@@ -4925,16 +4689,16 @@
         },
         {
             "name": "laminas/laminas-validator",
-            "version": "2.64.2",
+            "version": "2.64.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-validator.git",
-                "reference": "771e504760448ac7af660710237ceb93be602e08"
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/771e504760448ac7af660710237ceb93be602e08",
-                "reference": "771e504760448ac7af660710237ceb93be602e08",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
+                "reference": "e2e6631f599a9b0db1e23adb633c09a2f0c68bed",
                 "shasum": ""
             },
             "require": {
@@ -5005,20 +4769,20 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-26T21:29:17+00:00"
+            "time": "2025-06-16T14:38:00+00:00"
         },
         {
             "name": "laminas/laminas-view",
-            "version": "2.36.0",
+            "version": "2.39.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-view.git",
-                "reference": "ddc9207725cb50508ea48fcf1210dc8480264196"
+                "reference": "673f56af99b1780dc6babc3028d75724177969ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/ddc9207725cb50508ea48fcf1210dc8480264196",
-                "reference": "ddc9207725cb50508ea48fcf1210dc8480264196",
+                "url": "https://api.github.com/repos/laminas/laminas-view/zipball/673f56af99b1780dc6babc3028d75724177969ed",
+                "reference": "673f56af99b1780dc6babc3028d75724177969ed",
                 "shasum": ""
             },
             "require": {
@@ -5034,6 +4798,8 @@
                 "psr/container": "^1 || ^2"
             },
             "conflict": {
+                "amphp/dns": "<2.1.2",
+                "amphp/socket": "<2.3.1",
                 "container-interop/container-interop": "<1.2",
                 "laminas/laminas-router": "<3.0.1",
                 "laminas/laminas-session": "<2.12",
@@ -5041,23 +4807,23 @@
             },
             "require-dev": {
                 "laminas/laminas-authentication": "^2.18",
-                "laminas/laminas-coding-standard": "~2.5.0",
+                "laminas/laminas-coding-standard": "~3.0.1",
                 "laminas/laminas-feed": "^2.23",
-                "laminas/laminas-filter": "^2.39",
-                "laminas/laminas-http": "^2.20",
-                "laminas/laminas-i18n": "^2.29.0",
+                "laminas/laminas-filter": "^2.40",
+                "laminas/laminas-http": "^2.21",
+                "laminas/laminas-i18n": "^2.30.0",
                 "laminas/laminas-modulemanager": "^2.17",
                 "laminas/laminas-mvc": "^3.8.0",
                 "laminas/laminas-mvc-i18n": "^1.9",
-                "laminas/laminas-mvc-plugin-flashmessenger": "^1.10.1",
+                "laminas/laminas-mvc-plugin-flashmessenger": "^1.11.0",
                 "laminas/laminas-navigation": "^2.20.0",
                 "laminas/laminas-paginator": "^2.19.0",
-                "laminas/laminas-permissions-acl": "^2.16",
+                "laminas/laminas-permissions-acl": "^2.17",
                 "laminas/laminas-router": "^3.14.0",
-                "laminas/laminas-uri": "^2.12",
-                "phpunit/phpunit": "^10.5.38",
-                "psalm/plugin-phpunit": "^0.19.0",
-                "vimeo/psalm": "^5.26.1"
+                "laminas/laminas-uri": "^2.13",
+                "phpunit/phpunit": "^10.5.45",
+                "psalm/plugin-phpunit": "^0.19.5",
+                "vimeo/psalm": "^6.10.1"
             },
             "suggest": {
                 "laminas/laminas-authentication": "Laminas\\Authentication component",
@@ -5105,43 +4871,54 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2024-11-21T17:42:20+00:00"
+            "time": "2025-04-30T08:01:59+00:00"
         },
         {
             "name": "league/flysystem",
-            "version": "2.5.0",
+            "version": "3.30.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb"
+                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
-                "reference": "8aaffb653c5777781b0f7f69a5d937baf7ab6cdb",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/2203e3151755d874bb2943649dae1eb8533ac93e",
+                "reference": "2203e3151755d874bb2943649dae1eb8533ac93e",
                 "shasum": ""
             },
             "require": {
-                "ext-json": "*",
+                "league/flysystem-local": "^3.0.0",
                 "league/mime-type-detection": "^1.0.0",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.0.2"
             },
             "conflict": {
-                "guzzlehttp/ringphp": "<1.1.1"
+                "async-aws/core": "<1.19.0",
+                "async-aws/s3": "<1.14.0",
+                "aws/aws-sdk-php": "3.209.31 || 3.210.0",
+                "guzzlehttp/guzzle": "<7.0",
+                "guzzlehttp/ringphp": "<1.1.1",
+                "phpseclib/phpseclib": "3.0.15",
+                "symfony/http-client": "<5.2"
             },
             "require-dev": {
-                "async-aws/s3": "^1.5",
-                "async-aws/simple-s3": "^1.0",
-                "aws/aws-sdk-php": "^3.132.4",
+                "async-aws/s3": "^1.5 || ^2.0",
+                "async-aws/simple-s3": "^1.1 || ^2.0",
+                "aws/aws-sdk-php": "^3.295.10",
                 "composer/semver": "^3.0",
                 "ext-fileinfo": "*",
                 "ext-ftp": "*",
-                "friendsofphp/php-cs-fixer": "^3.2",
+                "ext-mongodb": "^1.3|^2",
+                "ext-zip": "*",
+                "friendsofphp/php-cs-fixer": "^3.5",
                 "google/cloud-storage": "^1.23",
-                "phpseclib/phpseclib": "^2.0",
-                "phpstan/phpstan": "^0.12.26",
-                "phpunit/phpunit": "^8.5 || ^9.4",
-                "sabre/dav": "^4.1"
+                "guzzlehttp/psr7": "^2.6",
+                "microsoft/azure-storage-blob": "^1.1",
+                "mongodb/mongodb": "^1.2|^2",
+                "phpseclib/phpseclib": "^3.0.36",
+                "phpstan/phpstan": "^1.10",
+                "phpunit/phpunit": "^9.5.11|^10.0",
+                "sabre/dav": "^4.6.0"
             },
             "type": "library",
             "autoload": {
@@ -5175,45 +4952,32 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/2.5.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.30.0"
             },
-            "funding": [
-                {
-                    "url": "https://ecologi.com/frankdejonge",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/frankdejonge",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-09-17T21:02:32+00:00"
+            "time": "2025-06-25T13:29:59+00:00"
         },
         {
             "name": "league/flysystem-aws-s3-v3",
-            "version": "2.5.0",
+            "version": "3.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem-aws-s3-v3.git",
-                "reference": "2ae435f7177fd5d3afc0090bc7f849093d8361e8"
+                "reference": "c6ff6d4606e48249b63f269eba7fabdb584e76a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/2ae435f7177fd5d3afc0090bc7f849093d8361e8",
-                "reference": "2ae435f7177fd5d3afc0090bc7f849093d8361e8",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-aws-s3-v3/zipball/c6ff6d4606e48249b63f269eba7fabdb584e76a9",
+                "reference": "c6ff6d4606e48249b63f269eba7fabdb584e76a9",
                 "shasum": ""
             },
             "require": {
-                "aws/aws-sdk-php": "^3.132.4",
-                "league/flysystem": "^2.0.0",
+                "aws/aws-sdk-php": "^3.295.10",
+                "league/flysystem": "^3.10.0",
                 "league/mime-type-detection": "^1.0.0",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.0.2"
             },
             "conflict": {
+                "guzzlehttp/guzzle": "<7.0",
                 "guzzlehttp/ringphp": "<1.1.1"
             },
             "type": "library",
@@ -5243,24 +5007,58 @@
                 "storage"
             ],
             "support": {
-                "issues": "https://github.com/thephpleague/flysystem-aws-s3-v3/issues",
-                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/2.5.0"
+                "source": "https://github.com/thephpleague/flysystem-aws-s3-v3/tree/3.29.0"
             },
-            "funding": [
+            "time": "2024-08-17T13:10:48+00:00"
+        },
+        {
+            "name": "league/flysystem-local",
+            "version": "3.30.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/flysystem-local.git",
+                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/flysystem-local/zipball/6691915f77c7fb69adfb87dcd550052dc184ee10",
+                "reference": "6691915f77c7fb69adfb87dcd550052dc184ee10",
+                "shasum": ""
+            },
+            "require": {
+                "ext-fileinfo": "*",
+                "league/flysystem": "^3.0.0",
+                "league/mime-type-detection": "^1.0.0",
+                "php": "^8.0.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "League\\Flysystem\\Local\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
                 {
-                    "url": "https://ecologi.com/frankdejonge",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/frankdejonge",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/league/flysystem",
-                    "type": "tidelift"
+                    "name": "Frank de Jonge",
+                    "email": "info@frankdejonge.nl"
                 }
             ],
-            "time": "2022-09-09T19:33:51+00:00"
+            "description": "Local filesystem adapter for Flysystem.",
+            "keywords": [
+                "Flysystem",
+                "file",
+                "files",
+                "filesystem",
+                "local"
+            ],
+            "support": {
+                "source": "https://github.com/thephpleague/flysystem-local/tree/3.30.0"
+            },
+            "time": "2025-05-21T10:34:19+00:00"
         },
         {
             "name": "league/mime-type-detection",
@@ -5320,40 +5118,40 @@
         },
         {
             "name": "magento/adobe-stock-integration",
-            "version": "2.1.6-p4",
+            "version": "2.1.7-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/adobe-stock-integration-2.1.6-p4.zip",
-                "shasum": "b8e8f7a5df707b03cdc38a96047a4dfd316c9134"
+                "url": "https://mirror.mage-os.org/packages/magento/adobe-stock-integration-2.1.7-p1.zip",
+                "shasum": "b771bf821b81ae2082f553018be370fb26577d51"
             },
             "require": {
-                "magento/module-adobe-stock-admin-ui": "1.3.4",
-                "magento/module-adobe-stock-asset": "1.3.3",
-                "magento/module-adobe-stock-asset-api": "2.0.3",
-                "magento/module-adobe-stock-client": "1.3.4",
-                "magento/module-adobe-stock-client-api": "2.1.4",
-                "magento/module-adobe-stock-image": "1.3.5",
-                "magento/module-adobe-stock-image-admin-ui": "1.3.5-p1",
-                "magento/module-adobe-stock-image-api": "1.3.3"
+                "magento/module-adobe-stock-admin-ui": "1.3.5",
+                "magento/module-adobe-stock-asset": "1.3.4",
+                "magento/module-adobe-stock-asset-api": "2.0.4",
+                "magento/module-adobe-stock-client": "1.3.5",
+                "magento/module-adobe-stock-client-api": "2.1.5",
+                "magento/module-adobe-stock-image": "1.3.6",
+                "magento/module-adobe-stock-image-admin-ui": "1.3.6",
+                "magento/module-adobe-stock-image-api": "1.3.4"
             },
             "type": "metapackage",
             "description": "Adobe Stock integration"
         },
         {
             "name": "magento/composer",
-            "version": "1.10.0",
+            "version": "1.10.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/composer-1.10.0.zip",
-                "shasum": "5602c8949d68729dfbae8325622f801f320394bf"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-composer-1.10.1.0.zip",
+                "shasum": "ce99aec9c972baed86115fe0d7be765f891e11a8"
             },
             "require": {
-                "composer/composer": "^2.0",
-                "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0",
+                "composer/composer": "^2.1.13",
+                "php": "~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0",
                 "symfony/console": "~4.4.0||~5.4.0||~6.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^9"
+                "phpunit/phpunit": "^9.5.10 || ^10"
             },
             "type": "library",
             "autoload": {
@@ -5409,16 +5207,16 @@
         },
         {
             "name": "magento/composer-root-update-plugin",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/composer-root-update-plugin-2.0.4.zip",
-                "shasum": "ff50c721f40b250e5bcf759702844a35687cfb46"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-composer-root-update-plugin-2.0.5.0.zip",
+                "shasum": "2e4c91fe0e9d725438134022a0a4dd3c649026db"
             },
             "require": {
                 "composer-plugin-api": "^1.0 || ^2.0",
                 "composer/composer": "^1.0 || ^2.0",
-                "php": "~7.3.0||~7.4.0||~8.0.0||~8.1.0||~8.2.0||~8.3.0"
+                "php": "~7.3.0||~7.4.0||~8.0.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "composer-plugin",
             "extra": {
@@ -5437,16 +5235,16 @@
         },
         {
             "name": "magento/ece-tools",
-            "version": "2002.2.1",
+            "version": "2002.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/ece-tools.git",
-                "reference": "42e7785961184f0dafd0f71b593fc72dd77bfb9a"
+                "reference": "7a543eacaa618bf3e4ca46d074d3702a4423f04e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/ece-tools/zipball/42e7785961184f0dafd0f71b593fc72dd77bfb9a",
-                "reference": "42e7785961184f0dafd0f71b593fc72dd77bfb9a",
+                "url": "https://api.github.com/repos/magento/ece-tools/zipball/7a543eacaa618bf3e4ca46d074d3702a4423f04e",
+                "reference": "7a543eacaa618bf3e4ca46d074d3702a4423f04e",
                 "shasum": ""
             },
             "require": {
@@ -5458,7 +5256,7 @@
                 "ext-sockets": "*",
                 "graylog2/gelf-php": "^2.0.1",
                 "guzzlehttp/guzzle": "^7.3 || ^7.5",
-                "illuminate/config": "^10.0 || ^11.0",
+                "illuminate/config": "^10.0 || ^11.0 || ^12.16",
                 "magento/magento-cloud-components": "^1.0.8",
                 "magento/magento-cloud-docker": "^1.4.0",
                 "magento/magento-cloud-patches": "^1.0.20",
@@ -5466,14 +5264,14 @@
                 "monolog/monolog": "^2.3 || ^2.7 || ^3.6",
                 "nesbot/carbon": "^1.0 || ^2.0 || ^3.8",
                 "php": "^8.0",
-                "psr/container": "^1.0",
+                "psr/container": "^1.0 || ^2.0",
                 "psr/log": "^1.0 || ^2.0 || ^3.0",
-                "symfony/config": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/dependency-injection": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/process": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/serializer": "^4.4 || ^5.4 || ^6.4",
-                "symfony/yaml": "^4.4 || ^5.1 || ^5.4 || ^6.4"
+                "symfony/config": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/dependency-injection": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/process": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/serializer": "^4.4 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/yaml": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2"
             },
             "conflict": {
                 "nesbot/carbon": ">=1.38 <2.0",
@@ -5489,7 +5287,7 @@
                 "codeception/module-db": "^3.0",
                 "codeception/module-phpbrowser": "^3.0",
                 "codeception/module-rest": "^3.0",
-                "consolidation/robo": "^3.0",
+                "consolidation/robo": "^3.0 || ^4.0 || ^5.0",
                 "funkjedi/composer-include-files": "^1.0",
                 "php-mock/php-mock-phpunit": "^2.0",
                 "phpmd/phpmd": "@stable",
@@ -5553,25 +5351,26 @@
             ],
             "description": "Provides tools to build and deploy Magento 2 Enterprise Edition",
             "support": {
-                "source": "https://github.com/magento/ece-tools/tree/2002.2.1",
+                "source": "https://github.com/magento/ece-tools/tree/2002.2.6",
                 "issues": "https://github.com/magento/ece-tools/issues"
             },
-            "time": "2025-02-06T15:27:29+00:00"
+            "time": "2025-06-03T12:25:07+00:00"
         },
         {
             "name": "magento/framework",
-            "version": "103.0.7-p4",
+            "version": "103.0.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/framework-103.0.7-p4.zip",
-                "shasum": "c19a5f6e2d93fc4f2d1b2cb725434d06ad312742"
+                "url": "https://mirror.mage-os.org/packages/magento/framework-103.0.8-p1.zip",
+                "shasum": "1ce685eae6b0ef5de2a319ba6fe6993cf6a81adb"
             },
             "require": {
-                "colinmollenhour/php-redis-session-abstract": "~1.5.3",
+                "colinmollenhour/php-redis-session-abstract": "^2.0",
                 "composer/composer": "^2.0, !=2.2.16",
                 "ext-bcmath": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
+                "ext-ftp": "*",
                 "ext-gd": "*",
                 "ext-hash": "*",
                 "ext-iconv": "*",
@@ -5584,13 +5383,9 @@
                 "guzzlehttp/guzzle": "^7.5",
                 "laminas/laminas-code": "^4.13",
                 "laminas/laminas-escaper": "^2.13",
-                "laminas/laminas-file": "^2.13",
                 "laminas/laminas-filter": "^2.33",
                 "laminas/laminas-http": "^2.15",
                 "laminas/laminas-i18n": "^2.17",
-                "laminas/laminas-mail": "^2.16",
-                "laminas/laminas-mime": "^2.9",
-                "laminas/laminas-oauth": "^2.6",
                 "laminas/laminas-permissions-acl": "^2.10",
                 "laminas/laminas-stdlib": "^3.11",
                 "laminas/laminas-uri": "^2.9",
@@ -5600,16 +5395,18 @@
                 "magento/zend-cache": "^1.16",
                 "magento/zend-db": "^1.16",
                 "magento/zend-pdf": "^1.16",
-                "monolog/monolog": "^2.7",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "monolog/monolog": "^3.6",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "psr/log": "^2 || ^3",
                 "ramsey/uuid": "^4.2",
                 "symfony/console": "^6.4",
                 "symfony/intl": "^6.4",
+                "symfony/mailer": "^6.4",
+                "symfony/mime": "^6.4",
                 "symfony/process": "^6.4",
                 "tedivm/jshrink": "^1.4",
                 "webonyx/graphql-php": "^15.0",
-                "wikimedia/less.php": "^3.2"
+                "wikimedia/less.php": "^5.0"
             },
             "suggest": {
                 "ext-imagick": "Use Image Magick >=3.0.0 as an optional alternative image processing library"
@@ -5638,16 +5435,16 @@
         },
         {
             "name": "magento/framework-amqp",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/framework-amqp-100.4.5.zip",
-                "shasum": "884160e6e952396b834d559af817e098a3ef0405"
+                "url": "https://mirror.mage-os.org/packages/magento/framework-amqp-100.4.6.zip",
+                "shasum": "674434df3850bb638ca4cc3a81a7910aa4e16f9c"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
-                "php-amqplib/php-amqplib": "~3.2.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0",
+                "php-amqplib/php-amqplib": "^3.2"
             },
             "type": "magento2-library",
             "autoload": {
@@ -5666,15 +5463,15 @@
         },
         {
             "name": "magento/framework-bulk",
-            "version": "101.0.3",
+            "version": "101.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/framework-bulk-101.0.3.zip",
-                "shasum": "46e8c7892aef20f2b41a340304b934cf9acfbcdb"
+                "url": "https://mirror.mage-os.org/packages/magento/framework-bulk-101.0.4.zip",
+                "shasum": "a49c460adbfbde71da0b275ffb6a6f75144e9df2"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-library",
             "autoload": {
@@ -5693,15 +5490,15 @@
         },
         {
             "name": "magento/framework-message-queue",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/framework-message-queue-100.4.7.zip",
-                "shasum": "7f0fdb61dabb11022d702d768f6688bf772edcbb"
+                "url": "https://mirror.mage-os.org/packages/magento/framework-message-queue-100.4.8.zip",
+                "shasum": "05546738c02299a8da6cce85092f60f6179c9423"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-library",
             "autoload": {
@@ -5748,87 +5545,88 @@
         },
         {
             "name": "magento/inventory-metapackage",
-            "version": "1.2.7-p4",
+            "version": "1.2.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/inventory-metapackage-1.2.7-p4.zip",
-                "shasum": "1b7ce8c39972113d28ce61bca7daf95be99ffca8"
+                "url": "https://mirror.mage-os.org/packages/magento/inventory-metapackage-1.2.8-p1.zip",
+                "shasum": "a55915fcd9a3c513d47d6f9cad6ac5230f26fcbe"
             },
             "require": {
                 "magento/inventory-composer-installer": "^1.2.0",
-                "magento/module-inventory": "1.2.5",
-                "magento/module-inventory-admin-ui": "1.2.5-p2",
-                "magento/module-inventory-advanced-checkout": "1.2.4",
-                "magento/module-inventory-api": "1.2.5",
-                "magento/module-inventory-bundle-import-export": "1.1.3",
-                "magento/module-inventory-bundle-product": "1.2.4",
-                "magento/module-inventory-bundle-product-admin-ui": "1.2.4",
-                "magento/module-inventory-bundle-product-indexer": "1.1.4",
-                "magento/module-inventory-cache": "1.2.5",
-                "magento/module-inventory-catalog": "1.3.2",
-                "magento/module-inventory-catalog-admin-ui": "1.2.5",
-                "magento/module-inventory-catalog-api": "1.3.5",
-                "magento/module-inventory-catalog-frontend-ui": "1.0.4",
-                "magento/module-inventory-catalog-search": "1.2.5",
-                "magento/module-inventory-catalog-search-bundle-product": "1.0.3",
-                "magento/module-inventory-catalog-search-configurable-product": "1.0.3",
-                "magento/module-inventory-configurable-product": "1.2.5",
-                "magento/module-inventory-configurable-product-admin-ui": "1.2.5",
-                "magento/module-inventory-configurable-product-frontend-ui": "1.0.5",
-                "magento/module-inventory-configurable-product-indexer": "1.2.5",
-                "magento/module-inventory-configuration": "1.2.4",
-                "magento/module-inventory-configuration-api": "1.2.3",
-                "magento/module-inventory-distance-based-source-selection": "1.2.4",
-                "magento/module-inventory-distance-based-source-selection-admin-ui": "1.2.3",
-                "magento/module-inventory-distance-based-source-selection-api": "1.2.3",
-                "magento/module-inventory-elasticsearch": "1.2.4",
-                "magento/module-inventory-export-stock": "1.2.4",
-                "magento/module-inventory-export-stock-api": "1.2.3",
-                "magento/module-inventory-graph-ql": "1.2.4",
-                "magento/module-inventory-grouped-product": "1.3.2",
-                "magento/module-inventory-grouped-product-admin-ui": "1.2.4",
-                "magento/module-inventory-grouped-product-indexer": "1.2.5",
-                "magento/module-inventory-import-export": "1.2.5",
-                "magento/module-inventory-in-store-pickup": "1.1.3",
-                "magento/module-inventory-in-store-pickup-admin-ui": "1.1.4",
-                "magento/module-inventory-in-store-pickup-api": "1.1.3",
-                "magento/module-inventory-in-store-pickup-frontend": "1.1.5",
-                "magento/module-inventory-in-store-pickup-graph-ql": "1.1.4",
-                "magento/module-inventory-in-store-pickup-multishipping": "1.1.3",
-                "magento/module-inventory-in-store-pickup-quote": "1.1.3",
-                "magento/module-inventory-in-store-pickup-quote-graph-ql": "1.1.3",
-                "magento/module-inventory-in-store-pickup-sales": "1.1.3",
-                "magento/module-inventory-in-store-pickup-sales-admin-ui": "1.1.5",
-                "magento/module-inventory-in-store-pickup-sales-api": "1.1.3-p1",
-                "magento/module-inventory-in-store-pickup-shipping": "1.1.4",
-                "magento/module-inventory-in-store-pickup-shipping-admin-ui": "1.1.3",
-                "magento/module-inventory-in-store-pickup-shipping-api": "1.1.3",
-                "magento/module-inventory-in-store-pickup-webapi-extension": "1.1.3",
-                "magento/module-inventory-indexer": "2.2.2",
-                "magento/module-inventory-low-quantity-notification": "1.2.4",
-                "magento/module-inventory-low-quantity-notification-admin-ui": "1.2.4",
-                "magento/module-inventory-low-quantity-notification-api": "1.2.4",
-                "magento/module-inventory-multi-dimensional-indexer-api": "1.2.3",
-                "magento/module-inventory-product-alert": "1.2.4",
-                "magento/module-inventory-quote-graph-ql": "1.0.4",
-                "magento/module-inventory-requisition-list": "1.2.5",
-                "magento/module-inventory-reservation-cli": "1.2.4",
-                "magento/module-inventory-reservations": "1.2.3",
-                "magento/module-inventory-reservations-api": "1.2.3",
-                "magento/module-inventory-sales": "1.3.2",
-                "magento/module-inventory-sales-admin-ui": "1.2.5",
-                "magento/module-inventory-sales-api": "1.2.4",
-                "magento/module-inventory-sales-async-order": "100.2.1",
-                "magento/module-inventory-sales-frontend-ui": "1.2.4",
-                "magento/module-inventory-setup-fixture-generator": "1.2.3",
-                "magento/module-inventory-shipping": "1.2.4",
-                "magento/module-inventory-shipping-admin-ui": "1.2.5",
-                "magento/module-inventory-source-deduction-api": "1.2.4",
-                "magento/module-inventory-source-selection": "1.2.3",
-                "magento/module-inventory-source-selection-api": "1.4.4",
-                "magento/module-inventory-swatches-frontend-ui": "1.0.3",
-                "magento/module-inventory-visual-merchandiser": "1.1.5",
-                "magento/module-inventory-wishlist": "1.0.4"
+                "magento/module-inventory": "1.2.6",
+                "magento/module-inventory-admin-ui": "1.2.6-p1",
+                "magento/module-inventory-advanced-checkout": "1.2.5",
+                "magento/module-inventory-api": "1.2.6",
+                "magento/module-inventory-bundle-import-export": "1.1.4",
+                "magento/module-inventory-bundle-product": "1.2.5",
+                "magento/module-inventory-bundle-product-admin-ui": "1.2.5",
+                "magento/module-inventory-bundle-product-indexer": "1.1.5",
+                "magento/module-inventory-cache": "1.2.6",
+                "magento/module-inventory-catalog": "1.3.3",
+                "magento/module-inventory-catalog-admin-ui": "1.2.6",
+                "magento/module-inventory-catalog-api": "1.3.6",
+                "magento/module-inventory-catalog-frontend-ui": "1.0.5",
+                "magento/module-inventory-catalog-rule": "100.2.0",
+                "magento/module-inventory-catalog-search": "1.2.6",
+                "magento/module-inventory-catalog-search-bundle-product": "1.0.4",
+                "magento/module-inventory-catalog-search-configurable-product": "1.0.4",
+                "magento/module-inventory-configurable-product": "1.2.6",
+                "magento/module-inventory-configurable-product-admin-ui": "1.2.6",
+                "magento/module-inventory-configurable-product-frontend-ui": "1.0.6",
+                "magento/module-inventory-configurable-product-indexer": "1.2.6",
+                "magento/module-inventory-configuration": "1.2.5",
+                "magento/module-inventory-configuration-api": "1.2.4",
+                "magento/module-inventory-distance-based-source-selection": "1.2.5",
+                "magento/module-inventory-distance-based-source-selection-admin-ui": "1.2.4",
+                "magento/module-inventory-distance-based-source-selection-api": "1.2.4",
+                "magento/module-inventory-elasticsearch": "1.2.5",
+                "magento/module-inventory-export-stock": "1.2.5",
+                "magento/module-inventory-export-stock-api": "1.2.4-p1",
+                "magento/module-inventory-graph-ql": "1.2.5",
+                "magento/module-inventory-grouped-product": "1.3.3",
+                "magento/module-inventory-grouped-product-admin-ui": "1.2.5",
+                "magento/module-inventory-grouped-product-indexer": "1.2.6",
+                "magento/module-inventory-import-export": "1.2.6",
+                "magento/module-inventory-in-store-pickup": "1.1.4",
+                "magento/module-inventory-in-store-pickup-admin-ui": "1.1.5-p1",
+                "magento/module-inventory-in-store-pickup-api": "1.1.4",
+                "magento/module-inventory-in-store-pickup-frontend": "1.1.6-p1",
+                "magento/module-inventory-in-store-pickup-graph-ql": "1.1.5",
+                "magento/module-inventory-in-store-pickup-multishipping": "1.1.4",
+                "magento/module-inventory-in-store-pickup-quote": "1.1.4",
+                "magento/module-inventory-in-store-pickup-quote-graph-ql": "1.1.4",
+                "magento/module-inventory-in-store-pickup-sales": "1.1.4",
+                "magento/module-inventory-in-store-pickup-sales-admin-ui": "1.1.6",
+                "magento/module-inventory-in-store-pickup-sales-api": "1.1.4",
+                "magento/module-inventory-in-store-pickup-shipping": "1.1.5",
+                "magento/module-inventory-in-store-pickup-shipping-admin-ui": "1.1.4",
+                "magento/module-inventory-in-store-pickup-shipping-api": "1.1.4",
+                "magento/module-inventory-in-store-pickup-webapi-extension": "1.1.4",
+                "magento/module-inventory-indexer": "2.2.3",
+                "magento/module-inventory-low-quantity-notification": "1.2.5",
+                "magento/module-inventory-low-quantity-notification-admin-ui": "1.2.5",
+                "magento/module-inventory-low-quantity-notification-api": "1.2.5",
+                "magento/module-inventory-multi-dimensional-indexer-api": "1.2.4",
+                "magento/module-inventory-product-alert": "1.2.5",
+                "magento/module-inventory-quote-graph-ql": "1.0.5",
+                "magento/module-inventory-requisition-list": "1.2.6",
+                "magento/module-inventory-reservation-cli": "1.2.5",
+                "magento/module-inventory-reservations": "1.2.4",
+                "magento/module-inventory-reservations-api": "1.2.4",
+                "magento/module-inventory-sales": "1.3.3",
+                "magento/module-inventory-sales-admin-ui": "1.2.6",
+                "magento/module-inventory-sales-api": "1.2.5",
+                "magento/module-inventory-sales-async-order": "100.2.2",
+                "magento/module-inventory-sales-frontend-ui": "1.2.5",
+                "magento/module-inventory-setup-fixture-generator": "1.2.4",
+                "magento/module-inventory-shipping": "1.2.5",
+                "magento/module-inventory-shipping-admin-ui": "1.2.6",
+                "magento/module-inventory-source-deduction-api": "1.2.5",
+                "magento/module-inventory-source-selection": "1.2.4",
+                "magento/module-inventory-source-selection-api": "1.4.5",
+                "magento/module-inventory-swatches-frontend-ui": "1.0.4",
+                "magento/module-inventory-visual-merchandiser": "1.1.6",
+                "magento/module-inventory-wishlist": "1.0.5"
             },
             "type": "metapackage",
             "description": "Metapackage with Magento Inventory modules for simple installation"
@@ -5839,7 +5637,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-de_de-100.4.0.zip",
-                "shasum": "7859092d4550d96b3f1bee320967cf8610eb0fb7"
+                "shasum": "b44d46791ab2fd3e9635d551c8efb5e193ab4c4c"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5862,7 +5660,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-en_us-100.4.0.zip",
-                "shasum": "3c59dd6512796f9aa221d6b4e1e0acfa6daabca5"
+                "shasum": "6b9b4e6baabb7a83d1bccc1e0afcd194f491b077"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5885,7 +5683,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-es_es-100.4.0.zip",
-                "shasum": "e0dbb35421f2d97cc2edf9606df2de5b5501c483"
+                "shasum": "cecf2c8604d3448ef16cf5de608dc105cbda2aeb"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5908,7 +5706,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-fr_fr-100.4.0.zip",
-                "shasum": "952ec467b9399390f6d238dfa9f1e686144cfa63"
+                "shasum": "2e99b25d6a1b5f50f12bedca8ca5f4c9fe807236"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5931,7 +5729,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-nl_nl-100.4.0.zip",
-                "shasum": "71d380ab82e82b92fd032ee0a050754b23277a39"
+                "shasum": "79b894db6f0b39f0e682f6b0429c7c4d91ee965c"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5954,7 +5752,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-pt_br-100.4.0.zip",
-                "shasum": "986f69f81aacb90335d3f03aa5687d52d5d077f6"
+                "shasum": "46eb83c31b8a3d0f125642bb2b852b4ef277647a"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5977,7 +5775,7 @@
             "dist": {
                 "type": "zip",
                 "url": "https://mirror.mage-os.org/packages/magento/language-zh_hans_cn-100.4.0.zip",
-                "shasum": "0ff092ec73bd95d92b3bb2ac8219240967d21dd9"
+                "shasum": "ed8034e30983a5a9f957de8f6caaa35f44848847"
             },
             "require": {
                 "magento/framework": "103.0.*"
@@ -5996,21 +5794,21 @@
         },
         {
             "name": "magento/magento-cloud-components",
-            "version": "1.1.1",
+            "version": "1.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-cloud-components.git",
-                "reference": "5e3879822899156366988a802ad9e5dbc854c054"
+                "reference": "c8414947f3c4fabf10f28c234949a38d1441b463"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-cloud-components/zipball/5e3879822899156366988a802ad9e5dbc854c054",
-                "reference": "5e3879822899156366988a802ad9e5dbc854c054",
+                "url": "https://api.github.com/repos/magento/magento-cloud-components/zipball/c8414947f3c4fabf10f28c234949a38d1441b463",
+                "reference": "c8414947f3c4fabf10f28c234949a38d1441b463",
                 "shasum": ""
             },
             "require": {
                 "colinmollenhour/cache-backend-redis": "^1.14.2",
-                "colinmollenhour/credis": "^1.6",
+                "colinmollenhour/credis": "^1.6.0 || ^1.13",
                 "ext-json": "*",
                 "php": "^8.0"
             },
@@ -6020,7 +5818,7 @@
                 "codeception/module-db": "^3.0",
                 "codeception/module-phpbrowser": "^3.0",
                 "codeception/module-rest": "^3.0",
-                "consolidation/robo": "^3.0",
+                "consolidation/robo": "^3.0 || ^4.0 || ^5.0",
                 "phpmd/phpmd": "@stable",
                 "phpstan/phpstan": "~1.2.0 || ^2.0",
                 "phpunit/phpunit": "^10.0",
@@ -6072,35 +5870,35 @@
             },
             "description": "Cloud Components Module for Magento 2.x",
             "support": {
-                "source": "https://github.com/magento/magento-cloud-components/tree/1.1.1",
+                "source": "https://github.com/magento/magento-cloud-components/tree/1.1.2",
                 "issues": "https://github.com/magento/magento-cloud-components/issues"
             },
-            "time": "2025-02-06T14:12:42+00:00"
+            "time": "2025-06-03T13:12:12+00:00"
         },
         {
             "name": "magento/magento-cloud-docker",
-            "version": "1.4.1",
+            "version": "1.4.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-cloud-docker.git",
-                "reference": "275f4678e919418e441e2e61e2af26421b925235"
+                "reference": "1c21dac0c0f5b867d546b5ad94beff671312fecd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-cloud-docker/zipball/275f4678e919418e441e2e61e2af26421b925235",
-                "reference": "275f4678e919418e441e2e61e2af26421b925235",
+                "url": "https://api.github.com/repos/magento/magento-cloud-docker/zipball/1c21dac0c0f5b867d546b5ad94beff671312fecd",
+                "reference": "1c21dac0c0f5b867d546b5ad94beff671312fecd",
                 "shasum": ""
             },
             "require": {
                 "composer/composer": "^1.9 || ^2.8 || !=2.2.16",
                 "composer/semver": "@stable",
                 "ext-json": "*",
-                "illuminate/config": "^8.77 || ^10.0 || ^11.0",
+                "illuminate/config": "^8.77 || ^10.0 || ^11.0 || ^12.16",
                 "php": "^8.0",
-                "symfony/config": "^4.4 || ^5.1|| ^5.4 || ^6.4",
-                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/dependency-injection": "^4.4 || ^5.1|| ^5.4 || ^6.4",
-                "symfony/yaml": "^4.4 || ^5.1 || ^5.4|| ^6.4"
+                "symfony/config": "^4.4 || ^5.1|| ^5.4 || ^6.4 || ^7.2",
+                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/dependency-injection": "^4.4 || ^5.1|| ^5.4 || ^6.4 || ^7.2",
+                "symfony/yaml": "^4.4 || ^5.1 || ^5.4|| ^6.4 || ^7.2"
             },
             "require-dev": {
                 "codeception/codeception": "^4.1 || ^5.1",
@@ -6108,7 +5906,7 @@
                 "codeception/module-db": "^1.0 || ^3.0",
                 "codeception/module-phpbrowser": "^1.0 || ^3.0",
                 "codeception/module-rest": "^1.2 || ^3.0",
-                "consolidation/robo": "^2.0 || ^3.0",
+                "consolidation/robo": "^2.0 || ^3.0 || ^4.0 || ^5.0",
                 "phpmd/phpmd": "@stable",
                 "phpstan/phpstan": "^1.8 || ^2.0",
                 "phpunit/phpunit": "^10.0",
@@ -6205,23 +6003,23 @@
             ],
             "description": "Magento Cloud Docker",
             "support": {
-                "source": "https://github.com/magento/magento-cloud-docker/tree/1.4.1",
+                "source": "https://github.com/magento/magento-cloud-docker/tree/1.4.3",
                 "issues": "https://github.com/magento/magento-cloud-docker/issues"
             },
-            "time": "2025-02-06T16:13:59+00:00"
+            "time": "2025-06-03T12:47:32+00:00"
         },
         {
             "name": "magento/magento-cloud-patches",
-            "version": "1.1.4",
+            "version": "1.1.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-cloud-patches.git",
-                "reference": "cb6707960637f6a120ce0d8523387198fc901f34"
+                "reference": "0b67038c8c1254b7357503b7fdedcffce5693e0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-cloud-patches/zipball/cb6707960637f6a120ce0d8523387198fc901f34",
-                "reference": "cb6707960637f6a120ce0d8523387198fc901f34",
+                "url": "https://api.github.com/repos/magento/magento-cloud-patches/zipball/0b67038c8c1254b7357503b7fdedcffce5693e0a",
+                "reference": "0b67038c8c1254b7357503b7fdedcffce5693e0a",
                 "shasum": ""
             },
             "require": {
@@ -6231,12 +6029,12 @@
                 "magento/quality-patches": "^1.1.0",
                 "monolog/monolog": "^2.3 || ^2.7 || ^3.6",
                 "php": "^8.0",
-                "symfony/config": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/dependency-injection": "^4.4 || ^5.1 || ^5.4 || ^6.4",
-                "symfony/process": "^4.4 || ^5.1 || ^5.4 || ^6.4",
+                "symfony/config": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/console": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/dependency-injection": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
+                "symfony/process": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2",
                 "symfony/proxy-manager-bridge": "^3.3||^4.3||^5.0||^6.0",
-                "symfony/yaml": "^4.4 || ^5.1 || ^5.4 || ^6.4"
+                "symfony/yaml": "^4.4 || ^5.1 || ^5.4 || ^6.4 || ^7.2"
             },
             "require-dev": {
                 "codeception/codeception": "^4.1 || ^5.1",
@@ -6244,7 +6042,7 @@
                 "codeception/module-db": "^1.0 || ^3.0",
                 "codeception/module-phpbrowser": "^1.0 || ^3.0",
                 "codeception/module-rest": "^1.2 || ^3.0",
-                "consolidation/robo": "^1.2 || ^3.0 || ^5.0",
+                "consolidation/robo": "^1.2 || ^3.0 || ^4.0 || ^5.0",
                 "phpmd/phpmd": "@stable",
                 "phpunit/phpunit": "^10.0",
                 "squizlabs/php_codesniffer": "^3.0"
@@ -6281,10 +6079,10 @@
             ],
             "description": "Provides critical fixes for Magento 2 Enterprise Edition",
             "support": {
-                "source": "https://github.com/magento/magento-cloud-patches/tree/1.1.4",
+                "source": "https://github.com/magento/magento-cloud-patches/tree/1.1.9",
                 "issues": "https://github.com/magento/magento-cloud-patches/issues"
             },
-            "time": "2025-02-13T14:35:56+00:00"
+            "time": "2025-06-09T11:01:59+00:00"
         },
         {
             "name": "magento/magento-composer-installer",
@@ -6368,35 +6166,102 @@
             ]
         },
         {
-            "name": "magento/magento2-base",
-            "version": "2.4.7-p4",
+            "name": "magento/magento-zf-db",
+            "version": "3.21.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/magento/magento-zf-db.git",
+                "reference": "6163987640ef843d9f229a6a2c7321b548560436"
+            },
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/magento2-base-2.4.7-p4.zip",
-                "shasum": "c8b6d1b51601a596da59b5998f819c36ce02e950"
+                "url": "https://api.github.com/repos/magento/magento-zf-db/zipball/6163987640ef843d9f229a6a2c7321b548560436",
+                "reference": "6163987640ef843d9f229a6a2c7321b548560436",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^3.7.1",
+                "php": "~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
+            },
+            "conflict": {
+                "zendframework/zend-db": "*"
+            },
+            "replace": {
+                "laminas/laminas-db": "^2.20"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "^2.4.0",
+                "laminas/laminas-eventmanager": "^3.6.0",
+                "laminas/laminas-hydrator": "^4.7",
+                "laminas/laminas-servicemanager": "^3.19.0",
+                "phpunit/phpunit": "^9.5.25"
+            },
+            "suggest": {
+                "laminas/laminas-eventmanager": "Laminas\\EventManager component",
+                "laminas/laminas-hydrator": "(^3.2 || ^4.3) Laminas\\Hydrator component for using HydratingResultSets",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "component": "Laminas\\Db",
+                    "config-provider": "Laminas\\Db\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Db\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Database abstraction layer, SQL abstraction, result set abstraction, and RowDataGateway and TableDataGateway implementations",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "db",
+                "laminas"
+            ],
+            "support": {
+                "chat": "https://laminas.dev/chat",
+                "docs": "https://docs.laminas.dev/laminas-db/",
+                "forum": "https://discourse.laminas.dev",
+                "issues": "https://github.com/laminas/laminas-db/issues",
+                "rss": "https://github.com/laminas/laminas-db/releases.atom",
+                "source": "https://github.com/laminas/laminas-db"
+            },
+            "time": "2025-02-26T05:37:14+00:00"
+        },
+        {
+            "name": "magento/magento2-base",
+            "version": "2.4.8-p1",
+            "dist": {
+                "type": "zip",
+                "url": "https://mirror.mage-os.org/packages/magento/magento2-base-2.4.8-p1.zip",
+                "shasum": "fb97d3ba97e6977eecf78a2846da4858d0a130e7"
             },
             "require": {
                 "composer/composer": "^2.0, !=2.2.16",
                 "ext-intl": "*",
                 "ext-mbstring": "*",
                 "laminas/laminas-code": "^4.13",
-                "laminas/laminas-di": "^3.13",
+                "laminas/laminas-di": "^3.15",
                 "laminas/laminas-eventmanager": "^3.11",
                 "laminas/laminas-http": "^2.15",
                 "laminas/laminas-i18n": "^2.17",
                 "laminas/laminas-modulemanager": "^2.11",
                 "laminas/laminas-mvc": "^3.6",
-                "laminas/laminas-server": "^2.16",
                 "laminas/laminas-servicemanager": "^3.16",
                 "laminas/laminas-soap": "^2.10",
                 "laminas/laminas-stdlib": "^3.11",
                 "laminas/laminas-uri": "^2.9",
                 "laminas/laminas-validator": "^2.23",
-                "magento/composer": "^1.10.0-beta1",
+                "magento/composer": "^1.10.1-beta1",
                 "magento/magento-composer-installer": "*",
-                "monolog/monolog": "^2.7",
+                "monolog/monolog": "^3.6",
                 "pelago/emogrifier": "^7.0",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "phpseclib/phpseclib": "^3.0",
                 "symfony/console": "^6.4",
                 "tedivm/jshrink": "^1.4",
@@ -6408,7 +6273,6 @@
             "replace": {
                 "components/jquery": "1.11.0",
                 "components/jqueryui": "1.10.4",
-                "tinymce/tinymce": "3.4.7",
                 "trentrichardson/jquery-timepicker-addon": "1.4.3",
                 "twbs/bootstrap": "3.1.0"
             },
@@ -6426,7 +6290,6 @@
                         "lib/web/jquery/jquery.min.js"
                     ],
                     "components/jqueryui": "lib/web/jquery/jquery-ui.js",
-                    "tinymce/tinymce": "lib/web/tiny_mce_5",
                     "trentrichardson/jquery-timepicker-addon": "lib/web/jquery/jquery-ui-timepicker-addon.js",
                     "twbs/bootstrap": "lib/web/jquery/jquery.tabs.js"
                 },
@@ -6732,10 +6595,6 @@
                         "lib/web/css"
                     ],
                     [
-                        "lib/web/extjs",
-                        "lib/web/extjs"
-                    ],
-                    [
                         "lib/web/fonts",
                         "lib/web/fonts"
                     ],
@@ -6818,10 +6677,6 @@
                     [
                         "lib/web/spacer.gif",
                         "lib/web/spacer.gif"
-                    ],
-                    [
-                        "lib/web/tiny_mce_5",
-                        "lib/web/tiny_mce_5"
                     ],
                     [
                         "lib/web/tiny_mce_6",
@@ -6945,11 +6800,11 @@
         },
         {
             "name": "magento/module-admin-adobe-ims",
-            "version": "100.5.2",
+            "version": "100.5.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-admin-adobe-ims-100.5.2.zip",
-                "shasum": "781d99135febb0a9066ff86756447562feef8450"
+                "url": "https://mirror.mage-os.org/packages/magento/module-admin-adobe-ims-100.5.3.zip",
+                "shasum": "d23f95c2f10c58b742cf6d5565a7a79c07f14efa"
             },
             "require": {
                 "magento/framework": "*",
@@ -6965,7 +6820,7 @@
                 "magento/module-security": "*",
                 "magento/module-store": "*",
                 "magento/module-user": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-theme": "*"
@@ -6987,17 +6842,17 @@
         },
         {
             "name": "magento/module-admin-adobe-ims-two-factor-auth",
-            "version": "1.0.1",
+            "version": "1.0.2",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-admin-adobe-ims-two-factor-auth-1.0.1.zip",
-                "shasum": "9b24169a166dca9f635b307d3d74a2a873afbb4a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-admin-adobe-ims-two-factor-auth-1.0.2.zip",
+                "shasum": "50faf97e594eff2fdd8edc3dcbd7237a4ecda99b"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-admin-adobe-ims": "100.5.*",
                 "magento/module-two-factor-auth": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7015,11 +6870,11 @@
         },
         {
             "name": "magento/module-admin-analytics",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-admin-analytics-100.4.6.zip",
-                "shasum": "acb53b45ed478c663f790d54e19c475723d5d988"
+                "url": "https://mirror.mage-os.org/packages/magento/module-admin-analytics-100.4.7.zip",
+                "shasum": "7dab7416368c8563c361e663fb6af01fb5bcf5a4"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7029,7 +6884,7 @@
                 "magento/module-release-notification": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7076,11 +6931,11 @@
         },
         {
             "name": "magento/module-admin-notification",
-            "version": "100.4.6-p3",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-admin-notification-100.4.6-p3.zip",
-                "shasum": "58fc9d6d2c2f2e2e739264a55e008b98fc21186a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-admin-notification-100.4.7.zip",
+                "shasum": "9f9fb3dce7f35a5ac3e7ab59040855e9517b107f"
             },
             "require": {
                 "lib-libxml": "*",
@@ -7090,7 +6945,7 @@
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7109,11 +6964,11 @@
         },
         {
             "name": "magento/module-adobe-ims",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-ims-2.2.1.zip",
-                "shasum": "9913eefc7ef84ee55831c50cfee1a379c4fe4f97"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-ims-2.2.2.zip",
+                "shasum": "a6a6717e9938c5de39fb07cef8c676823ae0987c"
             },
             "require": {
                 "magento/framework": "*",
@@ -7122,7 +6977,7 @@
                 "magento/module-backend": "*",
                 "magento/module-config": "*",
                 "magento/module-user": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7141,15 +6996,15 @@
         },
         {
             "name": "magento/module-adobe-ims-api",
-            "version": "2.2.1",
+            "version": "2.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-ims-api-2.2.1.zip",
-                "shasum": "75590fa1a625f77ef5eff4417dee676ca5278e88"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-ims-api-2.2.2.zip",
+                "shasum": "b1ddf4d4ec29db45474c44cf6f8c689bdfa9b882"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7168,11 +7023,11 @@
         },
         {
             "name": "magento/module-adobe-stock-admin-ui",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-admin-ui-1.3.4.zip",
-                "shasum": "363babd10a1bf84588e8f976be0009de2647e74b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-admin-ui-1.3.5.zip",
+                "shasum": "7742af948f6233a4b93526ce253d368081f3f1fe"
             },
             "require": {
                 "magento/framework": "*",
@@ -7181,7 +7036,7 @@
                 "magento/module-adobe-stock-client-api": "2.1.*",
                 "magento/module-backend": "*",
                 "magento/module-config": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cms": "*"
@@ -7203,11 +7058,11 @@
         },
         {
             "name": "magento/module-adobe-stock-asset",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-asset-1.3.3.zip",
-                "shasum": "19c7f29a9851a5a41bbbe8736e9e6fc88359e312"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-asset-1.3.4.zip",
+                "shasum": "731db192ca2d67da9b501778b5236a53642b4499"
             },
             "require": {
                 "magento/framework": "*",
@@ -7216,7 +7071,7 @@
                 "magento/module-config": "*",
                 "magento/module-media-gallery": "*",
                 "magento/module-media-gallery-api": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7235,15 +7090,15 @@
         },
         {
             "name": "magento/module-adobe-stock-asset-api",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-asset-api-2.0.3.zip",
-                "shasum": "f4cf9ad70c2abb656046f3d45f15b951d9cffd3d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-asset-api-2.0.4.zip",
+                "shasum": "97612ba308d103410c315e6209618cdcb077c5e8"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7262,18 +7117,18 @@
         },
         {
             "name": "magento/module-adobe-stock-client",
-            "version": "1.3.4",
+            "version": "1.3.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-client-1.3.4.zip",
-                "shasum": "26c58d7caf4ba507fbe195fdd37a9802df1468a1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-client-1.3.5.zip",
+                "shasum": "b290f5a76c9b27f607855188b3b092eacebc5796"
             },
             "require": {
-                "astock/stock-api-libphp": "^1.1.2",
+                "astock/stock-api-libphp": "^1.1.6",
                 "magento/framework": "*",
                 "magento/module-adobe-ims-api": "*",
                 "magento/module-adobe-stock-client-api": "2.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7292,15 +7147,15 @@
         },
         {
             "name": "magento/module-adobe-stock-client-api",
-            "version": "2.1.4",
+            "version": "2.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-client-api-2.1.4.zip",
-                "shasum": "ab0aca629bbad29916d85a9652d580253a319ffb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-client-api-2.1.5.zip",
+                "shasum": "cba63ee634f0e2499fc9da1b0a77e00db237cc40"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7319,11 +7174,11 @@
         },
         {
             "name": "magento/module-adobe-stock-image",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-1.3.5.zip",
-                "shasum": "1d0146942e29dd892edf82b31f10395f83c01337"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-1.3.6.zip",
+                "shasum": "736d2989a9f5a649a5d3560ad8a21b7c9f20e631"
             },
             "require": {
                 "magento/framework": "*",
@@ -7332,7 +7187,7 @@
                 "magento/module-adobe-stock-image-api": "1.3.*",
                 "magento/module-media-gallery-api": "*",
                 "magento/module-media-gallery-synchronization-api": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog": "*"
@@ -7354,11 +7209,11 @@
         },
         {
             "name": "magento/module-adobe-stock-image-admin-ui",
-            "version": "1.3.5-p1",
+            "version": "1.3.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-admin-ui-1.3.5-p1.zip",
-                "shasum": "4568dcd20a7d546c46630f221d69d8cbae484cc8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-admin-ui-1.3.6.zip",
+                "shasum": "c943d080133d75e3c29b7638d1270c1ce365bf2c"
             },
             "require": {
                 "magento/framework": "*",
@@ -7371,7 +7226,7 @@
                 "magento/module-media-gallery-api": "*",
                 "magento/module-media-gallery-ui": "*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cms": "*"
@@ -7393,15 +7248,15 @@
         },
         {
             "name": "magento/module-adobe-stock-image-api",
-            "version": "1.3.3",
+            "version": "1.3.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-api-1.3.3.zip",
-                "shasum": "1b60492b468677a1fd0cfb45ae965778d153c747"
+                "url": "https://mirror.mage-os.org/packages/magento/module-adobe-stock-image-api-1.3.4.zip",
+                "shasum": "baaa0541f74fbedcb9908271ed9e2111ca23de8b"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7420,11 +7275,11 @@
         },
         {
             "name": "magento/module-advanced-pricing-import-export",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-advanced-pricing-import-export-100.4.7.zip",
-                "shasum": "c85400ed94d008b00e7af77f06911243602c1d8d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-advanced-pricing-import-export-100.4.8.zip",
+                "shasum": "8c8734f6753dd7dfac36efc3a8c619f9103ed0f6"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7436,7 +7291,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-import-export": "101.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7455,11 +7310,11 @@
         },
         {
             "name": "magento/module-advanced-search",
-            "version": "100.4.5-p3",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-advanced-search-100.4.5-p3.zip",
-                "shasum": "9f129e662d946cda098396b12184728d324ed119"
+                "url": "https://mirror.mage-os.org/packages/magento/module-advanced-search-100.4.6.zip",
+                "shasum": "d4d163f6b10bb597d49e166772cb778ebed6a877"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7470,7 +7325,7 @@
                 "magento/module-customer": "103.0.*",
                 "magento/module-search": "101.1.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7489,17 +7344,17 @@
         },
         {
             "name": "magento/module-amqp",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-amqp-100.4.4.zip",
-                "shasum": "c6f0297a839ca24a554827b50548308fb06c1dd4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-amqp-100.4.5.zip",
+                "shasum": "5d351752e7240adc440732eda983f7f2f9bc55e0"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/framework-amqp": "100.4.*",
                 "magento/framework-message-queue": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7518,11 +7373,11 @@
         },
         {
             "name": "magento/module-analytics",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-analytics-100.4.7.zip",
-                "shasum": "a95474d578b349338bfd4bede3255664a68a3730"
+                "url": "https://mirror.mage-os.org/packages/magento/module-analytics-100.4.8.zip",
+                "shasum": "28ba595b7c2f0004f92a21c09d294dd30cf08070"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7530,7 +7385,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-integration": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7549,15 +7404,15 @@
         },
         {
             "name": "magento/module-application-performance-monitor",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-application-performance-monitor-100.4.0.zip",
-                "shasum": "a2d36b46fb4fcaf2c88425128798c70b141c6b73"
+                "url": "https://mirror.mage-os.org/packages/magento/module-application-performance-monitor-100.4.1.zip",
+                "shasum": "e5aadd9f4b4091cdec3fcfbbad4fcf96890f3109"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7575,17 +7430,17 @@
         },
         {
             "name": "magento/module-application-performance-monitor-new-relic",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-application-performance-monitor-new-relic-100.4.0.zip",
-                "shasum": "3b63a2e412a14cb4234850d48ce86c7b3193423d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-application-performance-monitor-new-relic-100.4.1.zip",
+                "shasum": "6d4566601cd88803361df237db900be4f03642c5"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-application-performance-monitor": "100.4.*",
                 "magento/module-new-relic-reporting": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "ext-newrelic": "This module requires New Relic's PHP extension in order to function."
@@ -7606,16 +7461,16 @@
         },
         {
             "name": "magento/module-async-config",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-async-config-100.4.0.zip",
-                "shasum": "52a2078920c289c1f80a40978f125f04f85373ab"
+                "url": "https://mirror.mage-os.org/packages/magento/module-async-config-100.4.1.zip",
+                "shasum": "7b15604407f506f022fe5a71e81a08e03246d425"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-config": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7633,11 +7488,11 @@
         },
         {
             "name": "magento/module-asynchronous-operations",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-asynchronous-operations-100.4.7.zip",
-                "shasum": "cc05c32e676f355458b60929dbef402531f7cc96"
+                "url": "https://mirror.mage-os.org/packages/magento/module-asynchronous-operations-100.4.8.zip",
+                "shasum": "73c6e30a90cf8b2b7f9a425f8a4cd556844b9485"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7646,7 +7501,7 @@
                 "magento/module-authorization": "100.4.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-admin-notification": "100.4.*",
@@ -7669,16 +7524,16 @@
         },
         {
             "name": "magento/module-authorization",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-authorization-100.4.7.zip",
-                "shasum": "cd7af2935e651fff86944cc957ca10be3e6ebe99"
+                "url": "https://mirror.mage-os.org/packages/magento/module-authorization-100.4.8.zip",
+                "shasum": "750b85c99f8f8565c004eaab3b6348311c43ab04"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7697,16 +7552,16 @@
         },
         {
             "name": "magento/module-aws-s3",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-aws-s3-100.4.5.zip",
-                "shasum": "8a0fff0a6c6cb0405807e5bf48d298dd113dfc8f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-aws-s3-100.4.6.zip",
+                "shasum": "2e7e30bd44929a3d2b4b168978d7a154dade1342"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-remote-storage": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7724,15 +7579,15 @@
         },
         {
             "name": "magento/module-aws-s3-page-builder",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-aws-s3-page-builder-1.0.4.zip",
-                "shasum": "9c53fbac8b33ef04c8d3973b23d40aa0fc135f8c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-aws-s3-page-builder-1.0.5.zip",
+                "shasum": "798fc0b5e096070bd704a58234b42b2a9ea8a862"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-aws-s3": "*",
@@ -7754,11 +7609,11 @@
         },
         {
             "name": "magento/module-backend",
-            "version": "102.0.7-p4",
+            "version": "102.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-backend-102.0.7-p4.zip",
-                "shasum": "9097f657fbc18f820f38709a994a4e6e24dad590"
+                "url": "https://mirror.mage-os.org/packages/magento/module-backend-102.0.8.zip",
+                "shasum": "53727debf485c626e48a7f0180e076c05dca3241"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7779,7 +7634,7 @@
                 "magento/module-translation": "100.4.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-theme": "101.1.*"
@@ -7802,18 +7657,18 @@
         },
         {
             "name": "magento/module-backup",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-backup-100.4.7.zip",
-                "shasum": "823b612969a4bc07ee9009f81a4c5fa9ccf0d3eb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-backup-100.4.8.zip",
+                "shasum": "bb9405080624aa5e671e13b3df6bcc7102d9d9fd"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-cron": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7832,11 +7687,11 @@
         },
         {
             "name": "magento/module-bundle",
-            "version": "101.0.7-p4",
+            "version": "101.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-101.0.7-p4.zip",
-                "shasum": "c2b27ffc2f68c456d7fc2409d46e15e671fdb447"
+                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-101.0.8.zip",
+                "shasum": "f9e47ac0cb49dcc3512cfdbae16d2a57682d0f02"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7856,7 +7711,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-bundle-sample-data": "Sample Data version: 100.4.*",
@@ -7880,24 +7735,23 @@
         },
         {
             "name": "magento/module-bundle-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-graph-ql-100.4.7.zip",
-                "shasum": "ce7b21e596219aa655ace54aacef93821309b2e4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-graph-ql-100.4.8.zip",
+                "shasum": "45d4956bfcfae18eb55905c409ec5bbabc23530c"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-bundle": "101.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-graph-ql": "100.4.*",
-                "magento/module-graph-ql": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-quote-graph-ql": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-sales-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7916,11 +7770,11 @@
         },
         {
             "name": "magento/module-bundle-import-export",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-import-export-100.4.6.zip",
-                "shasum": "c5a63f1604e4f237e9b2ec8b78966ce61d148cc4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-bundle-import-export-100.4.7.zip",
+                "shasum": "367fbb284aea8f7fa5148ed9ee2de06142c9e9d2"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -7930,7 +7784,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-import-export": "101.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7949,16 +7803,16 @@
         },
         {
             "name": "magento/module-cache-invalidate",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cache-invalidate-100.4.5.zip",
-                "shasum": "308c52ae94df5b59d3325c233de3d0aea67763c0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cache-invalidate-100.4.6.zip",
+                "shasum": "21f20b3836c9cda8987963a5433be3a6e0555ec4"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-page-cache": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -7977,23 +7831,23 @@
         },
         {
             "name": "magento/module-captcha",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-captcha-100.4.7.zip",
-                "shasum": "00087100a5ce06d0c3e9b220c2e58db19c28d674"
+                "url": "https://mirror.mage-os.org/packages/magento/module-captcha-100.4.8.zip",
+                "shasum": "77c3122f1f480f6d1b5eaf928f3402be58d784b5"
             },
             "require": {
-                "laminas/laminas-captcha": "^2.12",
-                "laminas/laminas-db": "^2.19",
+                "laminas/laminas-captcha": "^2.18",
                 "magento/framework": "103.0.*",
+                "magento/magento-zf-db": "^3.21",
                 "magento/module-authorization": "100.4.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8012,18 +7866,18 @@
         },
         {
             "name": "magento/module-cardinal-commerce",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cardinal-commerce-100.4.5.zip",
-                "shasum": "a5f243a097c352f5542b5675af60a9e3955d0f25"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cardinal-commerce-100.4.6.zip",
+                "shasum": "53ff70e72130763af49466012584401edd108af1"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-payment": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8042,11 +7896,11 @@
         },
         {
             "name": "magento/module-catalog",
-            "version": "104.0.7-p4",
+            "version": "104.0.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-104.0.7-p4.zip",
-                "shasum": "25deb658105091a78302a843f0f342546a1c6fa0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-104.0.8-p1.zip",
+                "shasum": "5d77c730a47959f45d6c4e0809d461312afbd21e"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8077,7 +7931,7 @@
                 "magento/module-url-rewrite": "102.0.*",
                 "magento/module-widget": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-sample-data": "Sample Data version: 100.4.*",
@@ -8101,17 +7955,17 @@
         },
         {
             "name": "magento/module-catalog-analytics",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-analytics-100.4.4.zip",
-                "shasum": "ecaad20f4be5149c76f317852a02c607c46b0a32"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-analytics-100.4.5.zip",
+                "shasum": "f50242a5d48fa0d4a284cab62d5eb3e3c015b4e8"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-catalog": "104.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8130,17 +7984,17 @@
         },
         {
             "name": "magento/module-catalog-cms-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-cms-graph-ql-100.4.3.zip",
-                "shasum": "03ec956d998d97d127893bb8040902ce2bf8a866"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-cms-graph-ql-100.4.4.zip",
+                "shasum": "db45b4d189c4033418d0ef702da5e046c4426e21"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-cms-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*",
@@ -8164,18 +8018,18 @@
         },
         {
             "name": "magento/module-catalog-customer-graph-ql",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-customer-graph-ql-100.4.6.zip",
-                "shasum": "32976253369f6467e5383bb9793bed00ce84c636"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-customer-graph-ql-100.4.7.zip",
+                "shasum": "7063d43bad81a588c4079890f7f125e6de9f0dc7"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-customer": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8194,11 +8048,11 @@
         },
         {
             "name": "magento/module-catalog-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-graph-ql-100.4.7.zip",
-                "shasum": "5dd7ca445e5247d3e7c35adf27b4d1c50ac54e73"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-graph-ql-100.4.8.zip",
+                "shasum": "f72db993f5ea2d90dd21f93137bc9a4561b3af2c"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8214,7 +8068,7 @@
                 "magento/module-graph-ql-resolver-cache": "100.4.*",
                 "magento/module-search": "101.1.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql-cache": "100.4.*",
@@ -8237,11 +8091,11 @@
         },
         {
             "name": "magento/module-catalog-import-export",
-            "version": "101.1.7-p3",
+            "version": "101.1.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-import-export-101.1.7-p3.zip",
-                "shasum": "fbe0ce8e436ac44b08619accd3ce263b1b2cfc1a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-import-export-101.1.8.zip",
+                "shasum": "58d0ed9d890bb94014458a261aa7e7f725d1fe0b"
             },
             "require": {
                 "ext-ctype": "*",
@@ -8257,7 +8111,7 @@
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8276,11 +8130,11 @@
         },
         {
             "name": "magento/module-catalog-inventory",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-inventory-100.4.7.zip",
-                "shasum": "c1940affdaefc329764829fb31cde28d895941c5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-inventory-100.4.8.zip",
+                "shasum": "34f235a4c596f0763278d68da5775a34b6e67de0"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8291,7 +8145,7 @@
                 "magento/module-quote": "101.2.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8311,19 +8165,21 @@
         },
         {
             "name": "magento/module-catalog-inventory-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-inventory-graph-ql-100.4.4.zip",
-                "shasum": "c0dc06a7cc406c601a37b6afd46c22a06f9532c2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-inventory-graph-ql-100.4.5.zip",
+                "shasum": "4ec64683597120ae8b988d2fc3b4b80ded25427f"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-inventory": "100.4.*",
                 "magento/module-graph-ql": "100.4.*",
+                "magento/module-quote": "101.2.*",
+                "magento/module-quote-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8342,17 +8198,17 @@
         },
         {
             "name": "magento/module-catalog-page-builder-analytics",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-page-builder-analytics-1.6.4.zip",
-                "shasum": "b289a7e488f4d8cdd99ea4993b9c473fd9487147"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-page-builder-analytics-1.6.5.zip",
+                "shasum": "9808e3a38726ad5979bc951566d161d3ebea0848"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-catalog": "*",
                 "magento/module-page-builder-analytics": "1.6.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8370,11 +8226,11 @@
         },
         {
             "name": "magento/module-catalog-rule",
-            "version": "101.2.7",
+            "version": "101.2.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-101.2.7.zip",
-                "shasum": "11d6e29119a5d9b6302855913c7cd23a01135035"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-101.2.8-p1.zip",
+                "shasum": "6a39d439b17105e8fd9be175f52c1995ead70df0"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8385,7 +8241,7 @@
                 "magento/module-rule": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-rule-sample-data": "Sample Data version: 100.4.*",
@@ -8408,11 +8264,11 @@
         },
         {
             "name": "magento/module-catalog-rule-configurable",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-configurable-100.4.6.zip",
-                "shasum": "9cb9759796857742084002dc0c5ac9a1f8bdaa96"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-configurable-100.4.7.zip",
+                "shasum": "b616ddd317dbeac6b24e96af3e282a489a5a9a86"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8420,7 +8276,7 @@
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-rule": "101.2.*",
                 "magento/module-configurable-product": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-rule": "101.2.*"
@@ -8442,18 +8298,16 @@
         },
         {
             "name": "magento/module-catalog-rule-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-graph-ql-100.4.4.zip",
-                "shasum": "0406b54cbde7f4273856f6ec7fc01da15956bff3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-rule-graph-ql-100.4.5-p1.zip",
+                "shasum": "36a7959de7e98fb8fff1666cef30ba18b1835b65"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
-            },
-            "suggest": {
-                "magento/module-catalog-rule": "101.2.*"
+                "magento/module-catalog-rule": "101.2.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8472,11 +8326,11 @@
         },
         {
             "name": "magento/module-catalog-search",
-            "version": "102.0.7-p3",
+            "version": "102.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-search-102.0.7-p3.zip",
-                "shasum": "49a0d79448e16627063580a42c8bba2386daef30"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-search-102.0.8.zip",
+                "shasum": "20a7728c91a0dad22b86b0d641814ec20da5626a"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8491,7 +8345,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -8513,11 +8367,11 @@
         },
         {
             "name": "magento/module-catalog-url-rewrite",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-url-rewrite-100.4.7.zip",
-                "shasum": "f045f5c9111b9e740bc41244db18c4c70dd30281"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-url-rewrite-100.4.8.zip",
+                "shasum": "c7205766f52286c3a205cc79905140ce2c8697a9"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8529,7 +8383,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-url-rewrite": "102.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-webapi": "100.4.*"
@@ -8551,11 +8405,11 @@
         },
         {
             "name": "magento/module-catalog-url-rewrite-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-url-rewrite-graph-ql-100.4.5.zip",
-                "shasum": "d6b096ba1fb25755e7c58fda7befdb4b40b0201e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-url-rewrite-graph-ql-100.4.6.zip",
+                "shasum": "dca2f6eede7f456a16aaa5cad7ab6537411b4006"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8563,7 +8417,7 @@
                 "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-url-rewrite-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*",
@@ -8587,11 +8441,11 @@
         },
         {
             "name": "magento/module-catalog-widget",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-widget-100.4.7.zip",
-                "shasum": "cc32cb853517a1033e43c0cdcfd973f87472b1a9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-catalog-widget-100.4.8.zip",
+                "shasum": "918b62df03575c18edf7dc45274e87635fee75f2"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8604,7 +8458,7 @@
                 "magento/module-theme": "101.1.*",
                 "magento/module-widget": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8623,11 +8477,11 @@
         },
         {
             "name": "magento/module-checkout",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-100.4.7.zip",
-                "shasum": "61afd76b2f98858cb8ec5647fac9b3241968cca1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-100.4.8.zip",
+                "shasum": "dfe346382c02beedb1348ffa3952d59a47c1e37c"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8652,7 +8506,7 @@
                 "magento/module-tax": "100.4.*",
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cookie": "100.4.*"
@@ -8674,11 +8528,11 @@
         },
         {
             "name": "magento/module-checkout-agreements",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-agreements-100.4.6.zip",
-                "shasum": "92cd88b42b3df92786dfd8eb907731a2a55383a2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-agreements-100.4.7.zip",
+                "shasum": "0fd631893177daa5ea0f8b02a5c1558661166f34"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8686,7 +8540,7 @@
                 "magento/module-checkout": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8705,17 +8559,17 @@
         },
         {
             "name": "magento/module-checkout-agreements-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-agreements-graph-ql-100.4.3.zip",
-                "shasum": "0ba272dc4e38f00ff2fcb7ec16be53ef5817d5e0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-checkout-agreements-graph-ql-100.4.4.zip",
+                "shasum": "03d96eb89e9bf80121c4cbaefb9a3c56802b813f"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-checkout-agreements": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -8737,11 +8591,11 @@
         },
         {
             "name": "magento/module-cms",
-            "version": "104.0.7-p4",
+            "version": "104.0.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cms-104.0.7-p4.zip",
-                "shasum": "6a62bc9c7058d98cfa95249940b616e4b34fb1e9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cms-104.0.8-p1.zip",
+                "shasum": "ae22ebaf126c01618ebdf97b656913b00f118ba4"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8754,7 +8608,7 @@
                 "magento/module-ui": "101.2.*",
                 "magento/module-variable": "100.4.*",
                 "magento/module-widget": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cms-sample-data": "Sample Data version: 100.4.*"
@@ -8776,11 +8630,11 @@
         },
         {
             "name": "magento/module-cms-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cms-graph-ql-100.4.4.zip",
-                "shasum": "0cdb46e0948692dd623505af92dd7afbddf9f661"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cms-graph-ql-100.4.5.zip",
+                "shasum": "d20637e602118c9112592833a5288b23e6e14bd0"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8788,7 +8642,7 @@
                 "magento/module-graph-ql-resolver-cache": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-widget": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*",
@@ -8812,17 +8666,17 @@
         },
         {
             "name": "magento/module-cms-page-builder-analytics",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cms-page-builder-analytics-1.6.4.zip",
-                "shasum": "3ddc4db73679c6f04467c5dc1aa495a1b1e40bb9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cms-page-builder-analytics-1.6.5.zip",
+                "shasum": "87e799b713871ca8b1eefa456b36f6a382dd764a"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-cms": "*",
                 "magento/module-page-builder-analytics": "1.6.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8840,18 +8694,18 @@
         },
         {
             "name": "magento/module-cms-url-rewrite",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cms-url-rewrite-100.4.6.zip",
-                "shasum": "b67ef224aed707a17b023eea10dfad4bbb26a347"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cms-url-rewrite-100.4.7.zip",
+                "shasum": "d2c945ed538447cbf325afc6ca72eda958d22ad8"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-cms": "104.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-url-rewrite": "102.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8870,11 +8724,11 @@
         },
         {
             "name": "magento/module-cms-url-rewrite-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cms-url-rewrite-graph-ql-100.4.5.zip",
-                "shasum": "ac4257b7b7e09f0304a9fc67451d514cc513fe90"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cms-url-rewrite-graph-ql-100.4.6.zip",
+                "shasum": "56b7c4394e77867b80e7997c60614e72c17860f6"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8882,7 +8736,7 @@
                 "magento/module-cms-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-url-rewrite-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*",
@@ -8905,17 +8759,17 @@
         },
         {
             "name": "magento/module-compare-list-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-compare-list-graph-ql-100.4.3.zip",
-                "shasum": "13328de5a8f0025466a49cf5e78d97a16101e9ac"
+                "url": "https://mirror.mage-os.org/packages/magento/module-compare-list-graph-ql-100.4.4.zip",
+                "shasum": "8793600349fd29537fb66e2c044d7b3e72c9dd2c"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-customer": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8934,11 +8788,11 @@
         },
         {
             "name": "magento/module-config",
-            "version": "101.2.7-p4",
+            "version": "101.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-config-101.2.7-p4.zip",
-                "shasum": "ffecbc3c0c6c60cc70993335f972fc86836956b2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-config-101.2.8.zip",
+                "shasum": "770a874f68abf0d03c8f0f69df74f4594b427755"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8950,7 +8804,7 @@
                 "magento/module-encryption-key": "100.4.*",
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -8969,11 +8823,11 @@
         },
         {
             "name": "magento/module-configurable-import-export",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-import-export-100.4.5.zip",
-                "shasum": "38ef2eb5c693ea1fae4bf08374953ecd24d7beee"
+                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-import-export-100.4.6.zip",
+                "shasum": "8bc47b7faedbbb9b69ed16f0efe71323a77a76d5"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -8983,7 +8837,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-import-export": "101.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9002,11 +8856,11 @@
         },
         {
             "name": "magento/module-configurable-product",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-100.4.7.zip",
-                "shasum": "20d7f0440a4dd729bc93281c7d0015830974a4bc"
+                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-100.4.8.zip",
+                "shasum": "d7a942e30ae3a3afa36e655a26386485e1e787d2"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9020,7 +8874,7 @@
                 "magento/module-quote": "101.2.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-widget": "100.4.*",
@@ -9050,11 +8904,11 @@
         },
         {
             "name": "magento/module-configurable-product-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-graph-ql-100.4.7.zip",
-                "shasum": "f1cf79f599b76b7b48eff231477ed78ec109c789"
+                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-graph-ql-100.4.8.zip",
+                "shasum": "d222b75bf164697da48824235eaf7e32805009b9"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9065,7 +8919,7 @@
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-quote-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9084,11 +8938,11 @@
         },
         {
             "name": "magento/module-configurable-product-sales",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-sales-100.4.4.zip",
-                "shasum": "91087ad9f5404fdbfed834e2cf7bdb6a879cc829"
+                "url": "https://mirror.mage-os.org/packages/magento/module-configurable-product-sales-100.4.5.zip",
+                "shasum": "742d46ac66c1a73c064bd7f1723845e69b1da682"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9096,7 +8950,7 @@
                 "magento/module-configurable-product": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9115,11 +8969,11 @@
         },
         {
             "name": "magento/module-contact",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-contact-100.4.6.zip",
-                "shasum": "d80eaff1e69d7d52e1b3c37085e346a0155acce5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-contact-100.4.7.zip",
+                "shasum": "b01674a684509d4223772009f428a33d40bef0da"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9127,7 +8981,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9146,16 +9000,16 @@
         },
         {
             "name": "magento/module-contact-graph-ql",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-contact-graph-ql-100.4.0.zip",
-                "shasum": "b42a71c610a9198e5f8596fa39627639422f2dd4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-contact-graph-ql-100.4.1.zip",
+                "shasum": "c8be7503563e4a4bafac47c2ee57297403e63254"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-contact": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -9177,16 +9031,16 @@
         },
         {
             "name": "magento/module-cookie",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cookie-100.4.7.zip",
-                "shasum": "ad9049599810d95125b85a02a0f14adc637585a6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cookie-100.4.8.zip",
+                "shasum": "003cd675c19fb25f671e124a92fdcc2e65fda1e3"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-backend": "102.0.*"
@@ -9208,19 +9062,17 @@
         },
         {
             "name": "magento/module-cron",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-cron-100.4.7.zip",
-                "shasum": "f412ca912b87117ee73520cf6c6f0abf8b917d8a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-cron-100.4.8.zip",
+                "shasum": "2eb9d90787d5b79a7d2c420871abcaedfd65e7fe"
             },
             "require": {
                 "magento/framework": "103.0.*",
+                "magento/module-config": "^100.1.2 || ^101.0",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
-            },
-            "suggest": {
-                "magento/module-config": "101.2.*"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9239,18 +9091,18 @@
         },
         {
             "name": "magento/module-csp",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-csp-100.4.6.zip",
-                "shasum": "d6a614cb09c1f3cd308b1fa20bb11bc64a5a74cf"
+                "url": "https://mirror.mage-os.org/packages/magento/module-csp-100.4.7.zip",
+                "shasum": "501db820c821f6aa12b50304ca35d831f62a9bb0"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-deploy": "100.4.*",
                 "magento/module-require-js": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9269,11 +9121,11 @@
         },
         {
             "name": "magento/module-currency-symbol",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-currency-symbol-100.4.5.zip",
-                "shasum": "a6123567fc334c82d9eefdcf3f69d17c523ef6a9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-currency-symbol-100.4.6.zip",
+                "shasum": "9b18d262fe2ca8894d45de0a93eeacb94ed4a760"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9282,7 +9134,7 @@
                 "magento/module-directory": "100.4.*",
                 "magento/module-page-cache": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9301,11 +9153,11 @@
         },
         {
             "name": "magento/module-customer",
-            "version": "103.0.7-p4",
+            "version": "103.0.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-customer-103.0.7-p4.zip",
-                "shasum": "4ebad9fe8afd3e864e66dbeddd6467d9bae3694a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-customer-103.0.8-p1.zip",
+                "shasum": "bea3f167059681c61e5edbf628c51d481de73f65"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9327,7 +9179,7 @@
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-asynchronous-operations": "100.4.*",
@@ -9352,17 +9204,17 @@
         },
         {
             "name": "magento/module-customer-analytics",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-customer-analytics-100.4.4.zip",
-                "shasum": "c4a8916d4842d8fa22a1ede32577e6b178e12feb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-customer-analytics-100.4.5.zip",
+                "shasum": "208b102d7f3aa45d6eccc7e8535d83f81402ed44"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-customer": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9381,17 +9233,17 @@
         },
         {
             "name": "magento/module-customer-downloadable-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-customer-downloadable-graph-ql-100.4.3.zip",
-                "shasum": "268ecc81718d18e115c81f7e117d0bc5bf641905"
+                "url": "https://mirror.mage-os.org/packages/magento/module-customer-downloadable-graph-ql-100.4.4.zip",
+                "shasum": "5f7e31cd28111475e09b62a14d483cb0e843c7e6"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-downloadable-graph-ql": "100.4.*",
                 "magento/module-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*"
@@ -9413,11 +9265,11 @@
         },
         {
             "name": "magento/module-customer-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-customer-graph-ql-100.4.7.zip",
-                "shasum": "e27158d8fd83d15dad2f768493d977eea83b1041"
+                "url": "https://mirror.mage-os.org/packages/magento/module-customer-graph-ql-100.4.8-p1.zip",
+                "shasum": "e65de4dd057b2c79210aa32fc2cf815ea69c28ba"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9431,9 +9283,10 @@
                 "magento/module-graph-ql-resolver-cache": "100.4.*",
                 "magento/module-integration": "100.4.*",
                 "magento/module-newsletter": "100.4.*",
+                "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9452,11 +9305,11 @@
         },
         {
             "name": "magento/module-customer-import-export",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-customer-import-export-100.4.7.zip",
-                "shasum": "27ffc5d179ad1e07a3ff43a30149b98aa9b69e36"
+                "url": "https://mirror.mage-os.org/packages/magento/module-customer-import-export-100.4.8.zip",
+                "shasum": "db8b6243985c92233183aa03a28ce38abcdc348d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9466,7 +9319,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-import-export": "101.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9485,11 +9338,11 @@
         },
         {
             "name": "magento/module-data-exporter",
-            "version": "103.3.18",
+            "version": "103.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-data-exporter-103.3.18.0.zip",
-                "shasum": "f0e5cc2fb293273fc9eeeb3e91ba46e3436aafdd"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-data-exporter-103.4.5.0.zip",
+                "shasum": "7106cbd6fa8e26ed0416533cafd673394db22129"
             },
             "require": {
                 "magento/framework": ">=103.0.4",
@@ -9515,11 +9368,11 @@
         },
         {
             "name": "magento/module-deploy",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-deploy-100.4.7.zip",
-                "shasum": "c51dd08dfca71fe997cad20f3d88d346917d1098"
+                "url": "https://mirror.mage-os.org/packages/magento/module-deploy-100.4.8.zip",
+                "shasum": "995a830d9ee55ac23a7451526eba602778a32890"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9527,7 +9380,7 @@
                 "magento/module-require-js": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9547,17 +9400,17 @@
         },
         {
             "name": "magento/module-developer",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-developer-100.4.7.zip",
-                "shasum": "78703922c83cbd0cdceae300d9f72542aa9ac7b8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-developer-100.4.8.zip",
+                "shasum": "b4b5018174359c41cfada04fca82e0a24f843294"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9576,11 +9429,11 @@
         },
         {
             "name": "magento/module-dhl",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-dhl-100.4.6.zip",
-                "shasum": "418cc81938c6d3a81c5ecdcd0b048aa6088f5427"
+                "url": "https://mirror.mage-os.org/packages/magento/module-dhl-100.4.7.zip",
+                "shasum": "e503fc84ce9841127044f1798d85f62d5e80c5c3"
             },
             "require": {
                 "lib-libxml": "*",
@@ -9594,7 +9447,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-checkout": "100.4.*"
@@ -9616,11 +9469,11 @@
         },
         {
             "name": "magento/module-directory",
-            "version": "100.4.7-p4",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-directory-100.4.7-p4.zip",
-                "shasum": "cd0345b8a1e5510df09b5917901042a45c13d840"
+                "url": "https://mirror.mage-os.org/packages/magento/module-directory-100.4.8.zip",
+                "shasum": "f73ceca712bea1300b3b0e5d8ef803611afc5467"
             },
             "require": {
                 "lib-libxml": "*",
@@ -9628,7 +9481,7 @@
                 "magento/module-backend": "102.0.*",
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9647,18 +9500,18 @@
         },
         {
             "name": "magento/module-directory-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-directory-graph-ql-100.4.5.zip",
-                "shasum": "adf1a652188f373a0174a00f07dedccf642c091b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-directory-graph-ql-100.4.6.zip",
+                "shasum": "fd5de27cc633ec90425ec27e6d6991414780dd50"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-directory": "100.4.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9677,11 +9530,11 @@
         },
         {
             "name": "magento/module-downloadable",
-            "version": "100.4.7-p4",
+            "version": "100.4.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-100.4.7-p4.zip",
-                "shasum": "3cc898c90410fd90e4ff08a84722c814042fb7dd"
+                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-100.4.8-p1.zip",
+                "shasum": "53b5a77c9ef3880b71fdb38ee4f192871d1882dd"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9701,7 +9554,7 @@
                 "magento/module-tax": "100.4.*",
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-downloadable-sample-data": "Sample Data version: 100.4.*"
@@ -9723,11 +9576,11 @@
         },
         {
             "name": "magento/module-downloadable-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-graph-ql-100.4.7.zip",
-                "shasum": "110b3e699196fb743ec643b1d2e0dbb298f46878"
+                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-graph-ql-100.4.8.zip",
+                "shasum": "3678def2c6817851ef8608caaf3624495bbb6463"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9737,7 +9590,7 @@
                 "magento/module-quote-graph-ql": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*",
@@ -9760,11 +9613,11 @@
         },
         {
             "name": "magento/module-downloadable-import-export",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-import-export-100.4.6.zip",
-                "shasum": "4cb13c452ade5b24eecf684136a5b84baaf6209a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-downloadable-import-export-100.4.7.zip",
+                "shasum": "b681c2224e8d2e14797c54a599870a09780483c8"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9774,7 +9627,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-import-export": "101.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9793,11 +9646,11 @@
         },
         {
             "name": "magento/module-eav",
-            "version": "102.1.7",
+            "version": "102.1.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-eav-102.1.7.zip",
-                "shasum": "b8612f8fff151c022af2f8d5413ef378b08415e7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-eav-102.1.8.zip",
+                "shasum": "8cf3e4aa5c4c75cfd649aee2356744978f81fecc"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9806,7 +9659,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9825,16 +9678,16 @@
         },
         {
             "name": "magento/module-eav-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-eav-graph-ql-100.4.4.zip",
-                "shasum": "149f2ddc8f2912d69c8a6e5085a8a67270c1ad07"
+                "url": "https://mirror.mage-os.org/packages/magento/module-eav-graph-ql-100.4.5.zip",
+                "shasum": "ef0cda78621de14adaa1796fbf05e6302825b822"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-eav": "102.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -9856,14 +9709,14 @@
         },
         {
             "name": "magento/module-elasticsearch",
-            "version": "101.0.7",
+            "version": "101.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-elasticsearch-101.0.7.zip",
-                "shasum": "f0ee4858931ada9d409212cc912652fae9355d11"
+                "url": "https://mirror.mage-os.org/packages/magento/module-elasticsearch-101.0.8.zip",
+                "shasum": "2095944e3d38759f2fdf05c3b50832ccf01a3996"
             },
             "require": {
-                "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0",
+                "elasticsearch/elasticsearch": "^8.15",
                 "magento/framework": "103.0.*",
                 "magento/module-advanced-search": "100.4.*",
                 "magento/module-catalog": "104.0.*",
@@ -9873,7 +9726,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-search": "101.1.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -9894,21 +9747,21 @@
             "description": "N/A"
         },
         {
-            "name": "magento/module-elasticsearch-7",
-            "version": "100.4.7",
+            "name": "magento/module-elasticsearch-8",
+            "version": "101.0.0",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-elasticsearch-7-100.4.7.zip",
-                "shasum": "586722c45e66bb23166c79e61ce0c204456911b8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-elasticsearch-8-101.0.0.zip",
+                "shasum": "a60421a8455a0e273fd700016e3f3567d1c56165"
             },
             "require": {
-                "elasticsearch/elasticsearch": "^7.17",
+                "elasticsearch/elasticsearch": "^8.15",
                 "magento/framework": "103.0.*",
                 "magento/module-advanced-search": "100.4.*",
                 "magento/module-catalog-search": "102.0.*",
                 "magento/module-elasticsearch": "101.0.*",
                 "magento/module-search": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -9919,7 +9772,7 @@
                     "registration.php"
                 ],
                 "psr-4": {
-                    "Magento\\Elasticsearch7\\": ""
+                    "Magento\\Elasticsearch8\\": ""
                 }
             },
             "license": [
@@ -9930,11 +9783,11 @@
         },
         {
             "name": "magento/module-email",
-            "version": "101.1.7-p4",
+            "version": "101.1.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-email-101.1.7-p4.zip",
-                "shasum": "c25439b8c714a1a488012c443fb0b5d2678c690b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-email-101.1.8-p1.zip",
+                "shasum": "b7dbf0a1780dedd60b979c75bef3f5a60aaf405d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -9947,7 +9800,7 @@
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-variable": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-theme": "101.1.*"
@@ -9969,17 +9822,17 @@
         },
         {
             "name": "magento/module-encryption-key",
-            "version": "100.4.5-p4",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-encryption-key-100.4.5-p4.zip",
-                "shasum": "912c88f450b43897f7a00ff9ee537b1d646620bd"
+                "url": "https://mirror.mage-os.org/packages/magento/module-encryption-key-100.4.6.zip",
+                "shasum": "06cae2630db677159d02685c75f0238b857f0c15"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-config": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -9998,11 +9851,11 @@
         },
         {
             "name": "magento/module-fedex",
-            "version": "100.4.5-p2",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-fedex-100.4.5-p2.zip",
-                "shasum": "e4513f9b80a5a7f9bae121c7f1f60391176112f5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-fedex-100.4.6.zip",
+                "shasum": "13b9d5d647ea93e32fea291eac51fe0f3488aaec"
             },
             "require": {
                 "lib-libxml": "*",
@@ -10015,7 +9868,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10034,11 +9887,11 @@
         },
         {
             "name": "magento/module-gift-message",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-gift-message-100.4.6.zip",
-                "shasum": "d292337d276fc78e4f99a23aa6d280758bb09971"
+                "url": "https://mirror.mage-os.org/packages/magento/module-gift-message-100.4.7.zip",
+                "shasum": "ab52de121ebfc49b976d2fef70b8e55b597ec79c"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10050,7 +9903,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-eav": "102.1.*",
@@ -10073,16 +9926,21 @@
         },
         {
             "name": "magento/module-gift-message-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-gift-message-graph-ql-100.4.5.zip",
-                "shasum": "1ff0722d369ac556af569b94f92fcb5f3f68bc66"
+                "url": "https://mirror.mage-os.org/packages/magento/module-gift-message-graph-ql-100.4.6.zip",
+                "shasum": "0fab6a1a8583ba4232526f2460afb4fa84cb9772"
             },
             "require": {
                 "magento/framework": "103.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-downloadable": "100.4.*",
                 "magento/module-gift-message": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-quote": "101.2.*",
+                "magento/module-sales": "103.0.*",
+                "magento/module-store": "101.1.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -10104,17 +9962,17 @@
         },
         {
             "name": "magento/module-google-adwords",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-google-adwords-100.4.4.zip",
-                "shasum": "cfaa8d2f057d5003cad203e98aff8e79073c9d2d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-google-adwords-100.4.5.zip",
+                "shasum": "b79de7867c72e34a40cc3fc214e24fca05dfa463"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10133,18 +9991,18 @@
         },
         {
             "name": "magento/module-google-analytics",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-google-analytics-100.4.3.zip",
-                "shasum": "52d0f22cca7b8a3f5daeab896fa5c62420816f74"
+                "url": "https://mirror.mage-os.org/packages/magento/module-google-analytics-100.4.4.zip",
+                "shasum": "45ee55c4870f8aa471ce89af9d7f227292286703"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-cookie": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -10166,18 +10024,18 @@
         },
         {
             "name": "magento/module-google-gtag",
-            "version": "100.4.2",
+            "version": "100.4.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-google-gtag-100.4.2.zip",
-                "shasum": "e365a545dbe9c8553c9ecfcf428cbd224c14bd8e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-google-gtag-100.4.3.zip",
+                "shasum": "a8653ea5d604cbc9fb42de73355347d38b7c572c"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-cookie": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -10199,11 +10057,11 @@
         },
         {
             "name": "magento/module-google-optimizer",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-google-optimizer-100.4.6.zip",
-                "shasum": "c28bddfcd28c1374906fffb2ac07ad38b16dab4d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-google-optimizer-100.4.7.zip",
+                "shasum": "523938e704950ddefc43cb5332ec36b6fb9196b8"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10214,7 +10072,7 @@
                 "magento/module-google-gtag": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10233,18 +10091,18 @@
         },
         {
             "name": "magento/module-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-100.4.7.zip",
-                "shasum": "3f9e824d6f517f84b1555825d2f1079c4527c5a2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-100.4.8.zip",
+                "shasum": "2ad7cbfc8879b0f86af1479a2cd9095e2943cbf9"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-authorization": "100.4.*",
                 "magento/module-eav": "102.1.*",
                 "magento/module-webapi": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "webonyx/graphql-php": "^15.0"
             },
             "suggest": {
@@ -10267,11 +10125,11 @@
         },
         {
             "name": "magento/module-graph-ql-cache",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-cache-100.4.4.zip",
-                "shasum": "f00ddd2ab6256b215ba80a0dfbb887dcd92e1a2e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-cache-100.4.5.zip",
+                "shasum": "7701f495d5252ce4a48506ad192d68707f5a074f"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10279,7 +10137,7 @@
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-integration": "100.4.*",
                 "magento/module-page-cache": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10298,17 +10156,17 @@
         },
         {
             "name": "magento/module-graph-ql-new-relic",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-new-relic-100.4.0.zip",
-                "shasum": "f2c9afefd91098e86205ecbc8c4b826491ad80bf"
+                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-new-relic-100.4.1.zip",
+                "shasum": "b393e18360ff4f69e3512cde2724b1226c89a443"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-new-relic-reporting": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10327,16 +10185,16 @@
         },
         {
             "name": "magento/module-graph-ql-resolver-cache",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-resolver-cache-100.4.0.zip",
-                "shasum": "ef568d1c516bf2cdcc7c8af3138cf52b55297ede"
+                "url": "https://mirror.mage-os.org/packages/magento/module-graph-ql-resolver-cache-100.4.1.zip",
+                "shasum": "96a482002cdbbc76d27f5af5aa3bd7a162e32311"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10385,18 +10243,18 @@
         },
         {
             "name": "magento/module-grouped-catalog-inventory",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-catalog-inventory-100.4.4.zip",
-                "shasum": "9efb39e75f197b8beeb5817ec71dd1ab5c55e874"
+                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-catalog-inventory-100.4.5.zip",
+                "shasum": "4199017077b3c9ac6e5453a56008bde9949a27f9"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-inventory": "100.4.*",
                 "magento/module-grouped-product": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10415,11 +10273,11 @@
         },
         {
             "name": "magento/module-grouped-import-export",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-import-export-100.4.5.zip",
-                "shasum": "72aa1c6c6af921c7b2277b5737cdcdea5505d45c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-import-export-100.4.6.zip",
+                "shasum": "37b23fc7414fc9dd1aeb4953d913336f6492c19f"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10428,7 +10286,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-grouped-product": "100.4.*",
                 "magento/module-import-export": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10447,11 +10305,11 @@
         },
         {
             "name": "magento/module-grouped-product",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-product-100.4.7.zip",
-                "shasum": "ea7de9c49ae3bad44fd80ad997c6c9afff144da0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-product-100.4.8.zip",
+                "shasum": "80a0589205f58cc789455668f0b9980b3291ff85"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10468,7 +10326,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-grouped-product-sample-data": "Sample Data version: 100.4.*"
@@ -10490,18 +10348,20 @@
         },
         {
             "name": "magento/module-grouped-product-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-product-graph-ql-100.4.7.zip",
-                "shasum": "6c4c614c3f9d667bc65b9ad096352b4db7b254bf"
+                "url": "https://mirror.mage-os.org/packages/magento/module-grouped-product-graph-ql-100.4.8.zip",
+                "shasum": "46ef09767e778400f97372772be6421d067b1b5b"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-grouped-product": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-quote": "101.2.*",
+                "magento/module-store-graph-ql": "100.4.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10520,11 +10380,11 @@
         },
         {
             "name": "magento/module-import-export",
-            "version": "101.0.7-p4",
+            "version": "101.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-import-export-101.0.7-p4.zip",
-                "shasum": "36621c278581eece607b9418da55c8ac750412be"
+                "url": "https://mirror.mage-os.org/packages/magento/module-import-export-101.0.8.zip",
+                "shasum": "fa174b9344180f1a8c5986f6c57df30367f0fee1"
             },
             "require": {
                 "ext-ctype": "*",
@@ -10535,7 +10395,7 @@
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10554,18 +10414,17 @@
         },
         {
             "name": "magento/module-indexer",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-indexer-100.4.7.zip",
-                "shasum": "e630508187d4c7e8a7922d225dac9c07940ae416"
+                "url": "https://mirror.mage-os.org/packages/magento/module-indexer-100.4.8.zip",
+                "shasum": "1978beffadbe0ee90b559b6fae6701cfb78f2d51"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/framework-amqp": "100.4.*",
                 "magento/module-backend": "102.0.*",
-                "magento/module-customer": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10584,11 +10443,11 @@
         },
         {
             "name": "magento/module-instant-purchase",
-            "version": "100.4.6-p3",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-instant-purchase-100.4.6-p3.zip",
-                "shasum": "1dc22fabb9fb53096a2b27f1c46ddc120a22e8ce"
+                "url": "https://mirror.mage-os.org/packages/magento/module-instant-purchase-100.4.7.zip",
+                "shasum": "27a84ca7d2e14241908231ac3ae19337877d4093"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10599,7 +10458,7 @@
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-vault": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10618,11 +10477,11 @@
         },
         {
             "name": "magento/module-integration",
-            "version": "100.4.7-p2",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-integration-100.4.7-p2.zip",
-                "shasum": "049ffd25526722756df5e1f680cf4b168c5edbed"
+                "url": "https://mirror.mage-os.org/packages/magento/module-integration-100.4.8.zip",
+                "shasum": "6afe0820bda7610819ccec38887880fbd10a77a6"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -10633,7 +10492,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10652,15 +10511,15 @@
         },
         {
             "name": "magento/module-integration-graph-ql",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-integration-graph-ql-100.4.0.zip",
-                "shasum": "30f596610d7fcbc2e76cc2bd12c1215805557176"
+                "url": "https://mirror.mage-os.org/packages/magento/module-integration-graph-ql-100.4.1.zip",
+                "shasum": "21c21b58c561ed53e2a911ed8b00554c60327b91"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10679,16 +10538,16 @@
         },
         {
             "name": "magento/module-inventory",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-1.2.5.zip",
-                "shasum": "3ca0b5a1b9345aa6e18feb8fea5b3be290c5e81f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-1.2.6.zip",
+                "shasum": "3fcc67b99a5f318c5d93f7e084227d2a10c0828d"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10707,21 +10566,21 @@
         },
         {
             "name": "magento/module-inventory-admin-ui",
-            "version": "1.2.5-p2",
+            "version": "1.2.6-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-admin-ui-1.2.5-p2.zip",
-                "shasum": "a6298aabe9a9c84419fbde4ed453172f9557908e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-admin-ui-1.2.6-p1.zip",
+                "shasum": "f7f69c0c802324ee68d9dc97178628735d7956d7"
             },
             "require": {
-                "magento/framework": "*",
-                "magento/module-backend": "*",
-                "magento/module-directory": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-directory": "100.4.*",
                 "magento/module-inventory": "1.2.*",
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
-                "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-ui": "101.2.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10740,18 +10599,18 @@
         },
         {
             "name": "magento/module-inventory-advanced-checkout",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-advanced-checkout-1.2.4.zip",
-                "shasum": "f39f1b325b13fbf0eaa7b80a1bf1e7f573cfd97d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-advanced-checkout-1.2.5.zip",
+                "shasum": "8337f7287408f8e35ee52b1fe2bb6a7eefd62141"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-advanced-checkout": "*"
@@ -10773,15 +10632,15 @@
         },
         {
             "name": "magento/module-inventory-api",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-api-1.2.5.zip",
-                "shasum": "99609da8f08f63129f232c13c70b3e88da7932ad"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-api-1.2.6.zip",
+                "shasum": "4f9614d01ca81a3c1c6db747e2add4978ee04f33"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10800,18 +10659,18 @@
         },
         {
             "name": "magento/module-inventory-bundle-import-export",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-import-export-1.1.3.zip",
-                "shasum": "0d892b910d592d18d52fcb4c9a21aad01349b25a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-import-export-1.1.4.zip",
+                "shasum": "663579f155e2559ad330711cefb46650f4c54eba"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-bundle-import-export": "*",
                 "magento/module-catalog-import-export": "*",
                 "magento/module-inventory-catalog-api": "1.3.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -10830,11 +10689,11 @@
         },
         {
             "name": "magento/module-inventory-bundle-product",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-1.2.4.zip",
-                "shasum": "a2f17cd5b16baefdbad1ceb8e61de63ea47c18b0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-1.2.5.zip",
+                "shasum": "0e7ed0601db3496ef77ff241460bb8f8b44ff1e3"
             },
             "require": {
                 "magento/framework": "*",
@@ -10845,7 +10704,7 @@
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-inventory": "*",
@@ -10868,11 +10727,11 @@
         },
         {
             "name": "magento/module-inventory-bundle-product-admin-ui",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-admin-ui-1.2.4.zip",
-                "shasum": "fe7c9ca38989702d01c60f98251d73e6475287a1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-admin-ui-1.2.5.zip",
+                "shasum": "a0d5070e34920868c175c729ba3283eb404ce108"
             },
             "require": {
                 "magento/framework": "*",
@@ -10881,7 +10740,7 @@
                 "magento/module-inventory-catalog-admin-ui": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-configuration-api": "1.2.*"
@@ -10903,11 +10762,11 @@
         },
         {
             "name": "magento/module-inventory-bundle-product-indexer",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-indexer-1.1.4.zip",
-                "shasum": "a7465987c7de5ec04a64309405074ed6ff2e2f3b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-bundle-product-indexer-1.1.5.zip",
+                "shasum": "e7f89e22b7fa5f8e29f53e81ca147bbbc403cbc0"
             },
             "require": {
                 "magento/framework": "*",
@@ -10918,7 +10777,7 @@
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-multi-dimensional-indexer-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*"
@@ -10940,17 +10799,17 @@
         },
         {
             "name": "magento/module-inventory-cache",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-cache-1.2.5.zip",
-                "shasum": "ba65152777b5ec57cfb445cceddacd7d4165e8e6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-cache-1.2.6.zip",
+                "shasum": "24d991c40579e12563fcf2d8aa1efde7fa80c90b"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-indexer": "2.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog": "*"
@@ -10972,11 +10831,11 @@
         },
         {
             "name": "magento/module-inventory-catalog",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-1.3.2.zip",
-                "shasum": "5c762d4967237b5fabfcd06697c379620b078628"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-1.3.3.zip",
+                "shasum": "9530245f2a6c1d68dd69c46c40c53b939f2b5fe6"
             },
             "require": {
                 "magento/framework": "*",
@@ -10990,7 +10849,7 @@
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-reservations-api": "1.2.*"
@@ -11012,11 +10871,11 @@
         },
         {
             "name": "magento/module-inventory-catalog-admin-ui",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-admin-ui-1.2.5.zip",
-                "shasum": "ba4f1a8b3dff493b5e21e19889fcbe6a7f5a5025"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-admin-ui-1.2.6.zip",
+                "shasum": "16c8df296d0b446fba1e149622322ebfc8cda626"
             },
             "require": {
                 "magento/framework": "*",
@@ -11029,7 +10888,7 @@
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-admin-ui": "1.2.*"
@@ -11051,15 +10910,15 @@
         },
         {
             "name": "magento/module-inventory-catalog-api",
-            "version": "1.3.5",
+            "version": "1.3.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-api-1.3.5.zip",
-                "shasum": "7480efeac3afe52660c96e93705083e4504c5f10"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-api-1.3.6.zip",
+                "shasum": "e0d9cf0292f8bd33b1da81c1a8a7e32b34bc822d"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11078,17 +10937,17 @@
         },
         {
             "name": "magento/module-inventory-catalog-frontend-ui",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-frontend-ui-1.0.4.zip",
-                "shasum": "2fecb40e5864f48740136a3ae1363bce5677077a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-frontend-ui-1.0.5.zip",
+                "shasum": "eb70e5b1add851a1ac3b36362f93703127bce4db"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-catalog": "1.3.*",
@@ -11110,12 +10969,49 @@
             "description": "N/A"
         },
         {
-            "name": "magento/module-inventory-catalog-search",
-            "version": "1.2.5",
+            "name": "magento/module-inventory-catalog-rule",
+            "version": "100.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-1.2.5.zip",
-                "shasum": "2132c93074c5e44b7e3aedbc4566b42e2bf7984c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-rule-100.2.0.zip",
+                "shasum": "1a1252ec0ce49068e2989c4da3473633cab5027b"
+            },
+            "require": {
+                "magento/framework": "*",
+                "magento/module-catalog": "*",
+                "magento/module-catalog-rule": "*",
+                "magento/module-inventory": "1.2.*",
+                "magento/module-inventory-catalog-api": "1.3.*",
+                "magento/module-inventory-indexer": "2.2.*",
+                "magento/module-inventory-sales-api": "1.2.*",
+                "magento/module-store": "*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
+            },
+            "suggest": {
+                "magento/module-rule": "*"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\InventoryCatalogRule\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0",
+                "AFL-3.0"
+            ],
+            "description": "N/A"
+        },
+        {
+            "name": "magento/module-inventory-catalog-search",
+            "version": "1.2.6",
+            "dist": {
+                "type": "zip",
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-1.2.6.zip",
+                "shasum": "f37e675f218bf1fb0dbb28bfe1c7713ea046b4f8"
             },
             "require": {
                 "magento/framework": "*",
@@ -11123,9 +11019,8 @@
                 "magento/module-catalog-search": "*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-indexer": "2.2.*",
-                "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11144,19 +11039,20 @@
         },
         {
             "name": "magento/module-inventory-catalog-search-bundle-product",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-bundle-product-1.0.3.zip",
-                "shasum": "83f1e4f8929f0f30193a950f5f649640bb8be055"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-bundle-product-1.0.4.zip",
+                "shasum": "6c2b67c858360a0f66139e5c8b10752a6000206f"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-bundle": "*",
                 "magento/module-catalog": "*",
-                "magento/module-eav": "*",
+                "magento/module-catalog-inventory": "*",
                 "magento/module-inventory-catalog-search": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-store": "*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11175,19 +11071,20 @@
         },
         {
             "name": "magento/module-inventory-catalog-search-configurable-product",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-configurable-product-1.0.3.zip",
-                "shasum": "cafbcaa52b4c38dbd9e88fffc91488dde981e0c8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-catalog-search-configurable-product-1.0.4.zip",
+                "shasum": "f0423d1574f7a4a272e160b1ce580a0457e18e37"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-catalog": "*",
+                "magento/module-catalog-inventory": "*",
                 "magento/module-configurable-product": "*",
-                "magento/module-eav": "*",
                 "magento/module-inventory-catalog-search": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-store": "*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11206,11 +11103,11 @@
         },
         {
             "name": "magento/module-inventory-configurable-product",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-1.2.5.zip",
-                "shasum": "c9f56a9a235cd2fb966e5b8fa6098ae0a191df96"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-1.2.6.zip",
+                "shasum": "01f02dce8ca89231f375aaabc0497add61ee0c34"
             },
             "require": {
                 "magento/framework": "*",
@@ -11225,7 +11122,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-sales": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*",
@@ -11248,11 +11145,11 @@
         },
         {
             "name": "magento/module-inventory-configurable-product-admin-ui",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-admin-ui-1.2.5.zip",
-                "shasum": "b7ec8c4ab57483e56e0545d841f16b0ae6448447"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-admin-ui-1.2.6.zip",
+                "shasum": "f0b79e9e3dff5360b92392dd7b62326f83550710"
             },
             "require": {
                 "magento/framework": "*",
@@ -11261,7 +11158,7 @@
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11280,18 +11177,18 @@
         },
         {
             "name": "magento/module-inventory-configurable-product-frontend-ui",
-            "version": "1.0.5",
+            "version": "1.0.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-frontend-ui-1.0.5.zip",
-                "shasum": "f49c8d3dde381d365ba3a9bcab2d33516d883781"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-frontend-ui-1.0.6.zip",
+                "shasum": "f74bd133ea0abbcb6079f841dfbbb0892ffe3d28"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-configurable-product": "*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-catalog": "1.3.*",
@@ -11314,11 +11211,11 @@
         },
         {
             "name": "magento/module-inventory-configurable-product-indexer",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-indexer-1.2.5.zip",
-                "shasum": "8b4b9ff5bb9d061941f7595faee92074b27aae30"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configurable-product-indexer-1.2.6.zip",
+                "shasum": "000d7efa44e831afeca2450f3ccd9c64f86a0eb7"
             },
             "require": {
                 "magento/framework": "*",
@@ -11328,7 +11225,7 @@
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-multi-dimensional-indexer-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*"
@@ -11350,11 +11247,11 @@
         },
         {
             "name": "magento/module-inventory-configuration",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configuration-1.2.4.zip",
-                "shasum": "4c56408fb33f84bd432578d84ea7f6b087a1b272"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configuration-1.2.5.zip",
+                "shasum": "a3c3bd760e7a4bd7711ccdb05a78e23c56caa44f"
             },
             "require": {
                 "magento/framework": "*",
@@ -11363,7 +11260,7 @@
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11382,15 +11279,15 @@
         },
         {
             "name": "magento/module-inventory-configuration-api",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configuration-api-1.2.3.zip",
-                "shasum": "e865b99939027300d8b3441e54ba25ea9efcb5fb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-configuration-api-1.2.4.zip",
+                "shasum": "91e21a8e5878cc8d7788b2acc85ad37bffb4f95e"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11409,11 +11306,11 @@
         },
         {
             "name": "magento/module-inventory-distance-based-source-selection",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-1.2.4.zip",
-                "shasum": "ce283ec1feb11b1c429069c067251942392dd4b5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-1.2.5.zip",
+                "shasum": "fa86ca25140a0788be3acc9d8a8f5c8ea59ee0d8"
             },
             "require": {
                 "magento/framework": "*",
@@ -11421,7 +11318,7 @@
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-distance-based-source-selection-api": "1.2.*",
                 "magento/module-inventory-source-selection-api": "1.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11440,15 +11337,15 @@
         },
         {
             "name": "magento/module-inventory-distance-based-source-selection-admin-ui",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-admin-ui-1.2.3.zip",
-                "shasum": "7a94f72cd9f492fab2a36db5df8beb099a37da10"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-admin-ui-1.2.4.zip",
+                "shasum": "c237579732c3f52aff5b14b42d0f19d78c6fae8e"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11467,16 +11364,16 @@
         },
         {
             "name": "magento/module-inventory-distance-based-source-selection-api",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-api-1.2.3.zip",
-                "shasum": "c9a3786ccd6e231886d8bd26939f787407450ed8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-distance-based-source-selection-api-1.2.4.zip",
+                "shasum": "17fafb3c76a85922ffc3d212a77ef7360a68e47b"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-source-selection-api": "1.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11495,11 +11392,11 @@
         },
         {
             "name": "magento/module-inventory-elasticsearch",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-elasticsearch-1.2.4.zip",
-                "shasum": "e9c727da08bc7802634fad3f813a11e111412be3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-elasticsearch-1.2.5.zip",
+                "shasum": "2abf01212fe74d5a6877f4d7c64564ce07de5e88"
             },
             "require": {
                 "magento/framework": "*",
@@ -11509,7 +11406,7 @@
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-elasticsearch": "*"
@@ -11531,11 +11428,11 @@
         },
         {
             "name": "magento/module-inventory-export-stock",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-export-stock-1.2.4.zip",
-                "shasum": "5becbf3103c2665dd8ebc50ff99d92707d8de9c2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-export-stock-1.2.5.zip",
+                "shasum": "6c83f908098cb5c182b533023f4227003c6b799e"
             },
             "require": {
                 "magento/framework": "*",
@@ -11550,7 +11447,7 @@
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-sales": "1.3.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11569,16 +11466,16 @@
         },
         {
             "name": "magento/module-inventory-export-stock-api",
-            "version": "1.2.3",
+            "version": "1.2.4-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-export-stock-api-1.2.3.zip",
-                "shasum": "60c37cef2b86938cf98b26d584060bd98da21eb7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-export-stock-api-1.2.4-p1.zip",
+                "shasum": "7eccf68f3df7e4fce24fc539e55b113163fa0ca1"
             },
             "require": {
-                "magento/framework": "*",
+                "magento/framework": "103.0.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11597,19 +11494,20 @@
         },
         {
             "name": "magento/module-inventory-graph-ql",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-graph-ql-1.2.4.zip",
-                "shasum": "87948e7a43d77cdec6733997690c4e4f5117dec3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-graph-ql-1.2.5.zip",
+                "shasum": "697d8696ac8e1671047c869c3296430a87c246ca"
             },
             "require": {
                 "magento/framework": "*",
+                "magento/module-bundle": "*",
                 "magento/module-catalog": "*",
                 "magento/module-inventory-catalog": "1.3.*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11628,17 +11526,17 @@
         },
         {
             "name": "magento/module-inventory-grouped-product",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-1.3.2.zip",
-                "shasum": "bab0ab04959718d43cb95cae690a83d4e7f52160"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-1.3.3.zip",
+                "shasum": "6510fb14e2fc3c041b57452088c1021ff272eb7e"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-grouped-product": "*",
                 "magento/module-inventory-catalog-api": "1.3.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*",
@@ -11663,11 +11561,11 @@
         },
         {
             "name": "magento/module-inventory-grouped-product-admin-ui",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-admin-ui-1.2.4.zip",
-                "shasum": "aca92295e7b83bf95c79790fa7366fee6d5dc4a7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-admin-ui-1.2.5.zip",
+                "shasum": "e2f1e759d2b658bf4b32b5a2f5b8d012594070ef"
             },
             "require": {
                 "magento/framework": "*",
@@ -11677,7 +11575,7 @@
                 "magento/module-inventory-catalog-admin-ui": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-configuration-api": "1.2.*"
@@ -11699,11 +11597,11 @@
         },
         {
             "name": "magento/module-inventory-grouped-product-indexer",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-indexer-1.2.5.zip",
-                "shasum": "62631656f14989b3ad9228e97ce5e9fb2dc96f1a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-grouped-product-indexer-1.2.6.zip",
+                "shasum": "065016cc886974074528533fec73057656a6171c"
             },
             "require": {
                 "magento/framework": "*",
@@ -11713,7 +11611,7 @@
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-multi-dimensional-indexer-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*"
@@ -11735,11 +11633,11 @@
         },
         {
             "name": "magento/module-inventory-import-export",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-import-export-1.2.5.zip",
-                "shasum": "1d47c62eb7de812fc395fbd862a7e20cbe433d70"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-import-export-1.2.6.zip",
+                "shasum": "e2679cfe2631f02d09105abaf2b3ca7e16e6cb40"
             },
             "require": {
                 "magento/framework": "*",
@@ -11749,7 +11647,7 @@
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-import-export": "*"
@@ -11771,11 +11669,11 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-1.1.3.zip",
-                "shasum": "452440e270688aae904a8f16fb112817c1eb4d35"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-1.1.4.zip",
+                "shasum": "0c990f32c7c93e9f09ee39726ba3b233417d5248"
             },
             "require": {
                 "magento/framework": "*",
@@ -11787,7 +11685,7 @@
                 "magento/module-inventory-in-store-pickup-api": "1.1.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-inventory-source-selection-api": "1.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11806,20 +11704,20 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-admin-ui",
-            "version": "1.1.4",
+            "version": "1.1.5-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-admin-ui-1.1.4.zip",
-                "shasum": "958b05fc643a10c40f36cc30c6c7424b7bcf346e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-admin-ui-1.1.5-p1.zip",
+                "shasum": "f3ec27fa68dc5dca3050b92708237491ba9f3d7d"
             },
             "require": {
-                "magento/framework": "*",
+                "magento/framework": "103.0.*",
                 "magento/module-inventory-admin-ui": "1.2.*",
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-catalog-api": "1.3.*",
                 "magento/module-inventory-in-store-pickup-api": "1.1.*",
-                "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-ui": "101.2.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11838,16 +11736,16 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-api",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-api-1.1.3.zip",
-                "shasum": "b3b95e43ec0d382e19519a546c9a88d42f56d741"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-api-1.1.4.zip",
+                "shasum": "802f1232041f0b848001c14fd27bad8394ffcec1"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11866,20 +11764,20 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-frontend",
-            "version": "1.1.5",
+            "version": "1.1.6-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-frontend-1.1.5.zip",
-                "shasum": "dfb92ad4dba7fe8bf2ce66354962e144881da7e3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-frontend-1.1.6-p1.zip",
+                "shasum": "2c29d52e08e690994814d5757ceb9eb94d00f77a"
             },
             "require": {
-                "magento/framework": "*",
-                "magento/module-checkout": "*",
+                "magento/framework": "103.0.*",
+                "magento/module-checkout": "100.4.*",
                 "magento/module-inventory-in-store-pickup-api": "1.1.*",
                 "magento/module-inventory-in-store-pickup-sales-api": "1.1.*",
                 "magento/module-inventory-in-store-pickup-shipping-api": "1.1.*",
-                "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-store": "101.1.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11898,18 +11796,18 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-graph-ql",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-graph-ql-1.1.4.zip",
-                "shasum": "bef723b655e3d958a53f514af9254f5c9a5264d6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-graph-ql-1.1.5.zip",
+                "shasum": "f4fe83d3f658cdd8dcb76b76e8d7c1148adc3d02"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-in-store-pickup-api": "1.1.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11928,18 +11826,18 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-multishipping",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-multishipping-1.1.3.zip",
-                "shasum": "400ac16feba45adc74d7792bc7fe6824117effb2"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-multishipping-1.1.4.zip",
+                "shasum": "f37abd83cb6319fe462539defdd9a9876573c912"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-checkout": "*",
                 "magento/module-inventory-in-store-pickup-shipping-api": "1.1.*",
                 "magento/module-quote": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11958,11 +11856,11 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-quote",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-quote-1.1.3.zip",
-                "shasum": "3ef253751f4b7afedf935aabec6711459b0ee1f7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-quote-1.1.4.zip",
+                "shasum": "ccfd08905c471bdfe7472410ce2cbc47122bebb1"
             },
             "require": {
                 "magento/framework": "*",
@@ -11972,7 +11870,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -11991,18 +11889,19 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-quote-graph-ql",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-quote-graph-ql-1.1.3.zip",
-                "shasum": "0e7c474e421c01b68f737d0415575c3d4b9cf5ba"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-quote-graph-ql-1.1.4.zip",
+                "shasum": "d0ab0e90787415620daefbe064824d263794979d"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-graph-ql": "*",
+                "magento/module-inventory": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-quote-graph-ql": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12021,11 +11920,11 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-sales",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-1.1.3.zip",
-                "shasum": "3fb42c480433b78dc685561bba64402bb9d823ef"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-1.1.4.zip",
+                "shasum": "237b5067064e006284b4af2741840521d06392f8"
             },
             "require": {
                 "magento/framework": "*",
@@ -12035,7 +11934,7 @@
                 "magento/module-inventory-source-selection-api": "1.4.*",
                 "magento/module-sales": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12054,11 +11953,11 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-sales-admin-ui",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-admin-ui-1.1.5.zip",
-                "shasum": "7a5b89c8eb8b123bf79de00aa604610b0add1d8e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-admin-ui-1.1.6.zip",
+                "shasum": "f808e55be759bcab301f4c54e6bee48ff653b03d"
             },
             "require": {
                 "magento/framework": "*",
@@ -12071,7 +11970,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-sales": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12090,15 +11989,15 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-sales-api",
-            "version": "1.1.3-p1",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-api-1.1.3-p1.zip",
-                "shasum": "501d6e3e8d9c5485163aad5668ebcb465b1f5036"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-sales-api-1.1.4.zip",
+                "shasum": "ff95e0d66bf21d8db9a8894799c2049cd40bb568"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12117,11 +12016,11 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-shipping",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-1.1.4.zip",
-                "shasum": "e44f0ab3a08e4eddecd7c01a9636035c87f4b761"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-1.1.5.zip",
+                "shasum": "bf5a4e47108995c5e687f35a2d1c2f1bacf67369"
             },
             "require": {
                 "magento/framework": "*",
@@ -12131,7 +12030,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12150,16 +12049,16 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-shipping-admin-ui",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-admin-ui-1.1.3.zip",
-                "shasum": "883823aa94c7c656a4ecf93ab59c690c6748c30b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-admin-ui-1.1.4.zip",
+                "shasum": "2d55be012a01278334f22e696f6bd540e2b0b8c9"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-in-store-pickup-shipping-api": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-shipping": "*"
@@ -12181,18 +12080,18 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-shipping-api",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-api-1.1.3.zip",
-                "shasum": "6af0828c14e20fd12a6d6decba773a3f0e9bab19"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-shipping-api-1.1.4.zip",
+                "shasum": "245887d3b911d62f0588d64f0d3e9a9272a075fa"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-quote": "*",
                 "magento/module-shipping": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12211,16 +12110,16 @@
         },
         {
             "name": "magento/module-inventory-in-store-pickup-webapi-extension",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-webapi-extension-1.1.3.zip",
-                "shasum": "edb39e9fb6ade82014e55447ea53522aa7e4d77c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-in-store-pickup-webapi-extension-1.1.4.zip",
+                "shasum": "e3eb3831248dba5708ddb0951a0467098fbd625f"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-webapi": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12240,11 +12139,11 @@
         },
         {
             "name": "magento/module-inventory-indexer",
-            "version": "2.2.2",
+            "version": "2.2.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-indexer-2.2.2.zip",
-                "shasum": "330f39a67b1248c4c8483c7b49e1ed3ec7147785"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-indexer-2.2.3.zip",
+                "shasum": "f02c9096afcf09533cdc1a01081f4456ab124523"
             },
             "require": {
                 "magento/framework": "*",
@@ -12256,7 +12155,7 @@
                 "magento/module-inventory-multi-dimensional-indexer-api": "1.2.*",
                 "magento/module-inventory-sales": "1.3.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog": "*"
@@ -12278,11 +12177,11 @@
         },
         {
             "name": "magento/module-inventory-low-quantity-notification",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-1.2.4.zip",
-                "shasum": "e3c823cd8cf82abfffdc4fc483988195cbf7224b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-1.2.5.zip",
+                "shasum": "e1672af7ff8d54ed0aed73483aa84fc5343ca420"
             },
             "require": {
                 "magento/framework": "*",
@@ -12295,7 +12194,7 @@
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-low-quantity-notification-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12314,11 +12213,11 @@
         },
         {
             "name": "magento/module-inventory-low-quantity-notification-admin-ui",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-admin-ui-1.2.4.zip",
-                "shasum": "08dc45948425320a2b4788af5cb6ae53cbdc1460"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-admin-ui-1.2.5.zip",
+                "shasum": "36abcf4c82b2c1d53d149dedfbc2187a1b75036d"
             },
             "require": {
                 "magento/framework": "*",
@@ -12331,7 +12230,7 @@
                 "magento/module-inventory-low-quantity-notification-api": "1.2.*",
                 "magento/module-reports": "*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12350,15 +12249,15 @@
         },
         {
             "name": "magento/module-inventory-low-quantity-notification-api",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-api-1.2.4.zip",
-                "shasum": "33d60e99aa0d1ab5764c1bc64bcd15073c2e313b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-low-quantity-notification-api-1.2.5.zip",
+                "shasum": "33d500b8bb7d2ad752e994b20c102050ebc486a1"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12377,15 +12276,15 @@
         },
         {
             "name": "magento/module-inventory-multi-dimensional-indexer-api",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-multi-dimensional-indexer-api-1.2.3.zip",
-                "shasum": "ef3bf92d80f3ec53d0c590af1c0efa526c1661e6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-multi-dimensional-indexer-api-1.2.4.zip",
+                "shasum": "fb84c45db245ca3701a310213bf463f3aad97786"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12404,11 +12303,11 @@
         },
         {
             "name": "magento/module-inventory-product-alert",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-product-alert-1.2.4.zip",
-                "shasum": "08bffe526b9a2cfe4aadf375a6add3598d586606"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-product-alert-1.2.5.zip",
+                "shasum": "e319c7ce00e0eb88810d25734a9dc6baf240c597"
             },
             "require": {
                 "magento/framework": "*",
@@ -12418,7 +12317,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-product-alert": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-product-alert": "*"
@@ -12440,11 +12339,11 @@
         },
         {
             "name": "magento/module-inventory-quote-graph-ql",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-quote-graph-ql-1.0.4.zip",
-                "shasum": "6e9881a1afe60cc99c122d7747945026f3b7f721"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-quote-graph-ql-1.0.5.zip",
+                "shasum": "a08b3433a198451e1dc3ee636e8be0fab8b798cf"
             },
             "require": {
                 "magento/framework": "*",
@@ -12452,7 +12351,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-quote-graph-ql": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12471,18 +12370,18 @@
         },
         {
             "name": "magento/module-inventory-requisition-list",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-requisition-list-1.2.5.zip",
-                "shasum": "1865c55cb1b183b3da09227b3e2970d4f2a67d5e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-requisition-list-1.2.6.zip",
+                "shasum": "a31b518fa4d1956dfb5a5b7c7e398a1e3d86519d"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-catalog": "*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-requisition-list": "*"
@@ -12503,11 +12402,11 @@
         },
         {
             "name": "magento/module-inventory-reservation-cli",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservation-cli-1.2.4.zip",
-                "shasum": "da03d544b82cbb985dd5c297f4a894fd61e2d246"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservation-cli-1.2.5.zip",
+                "shasum": "b947c7dbeb90413a34991bb76e6315e4dce22e82"
             },
             "require": {
                 "magento/framework": "*",
@@ -12517,7 +12416,7 @@
                 "magento/module-inventory-reservations-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-sales": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12536,16 +12435,16 @@
         },
         {
             "name": "magento/module-inventory-reservations",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservations-1.2.3.zip",
-                "shasum": "608c5ce69cc09b46f7502825e63db94acce02f0f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservations-1.2.4.zip",
+                "shasum": "cae50585decda6cbb6f7145d7d1909843945b9d5"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-reservations-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12564,15 +12463,15 @@
         },
         {
             "name": "magento/module-inventory-reservations-api",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservations-api-1.2.3.zip",
-                "shasum": "a90e018f1586d5b88c2d6d49d45ea4494ef4df52"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-reservations-api-1.2.4.zip",
+                "shasum": "e3f77b7aff3f911ddf311cd3598c595536b499a7"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12591,11 +12490,11 @@
         },
         {
             "name": "magento/module-inventory-sales",
-            "version": "1.3.2",
+            "version": "1.3.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-1.3.2.zip",
-                "shasum": "278a90ba55969016be82168bac64a742b66df4c1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-1.3.3.zip",
+                "shasum": "af74bcd649517b3590981660a6877290ff9932dc"
             },
             "require": {
                 "magento/framework": "*",
@@ -12612,7 +12511,7 @@
                 "magento/module-sales": "*",
                 "magento/module-sales-inventory": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "require-dev": {
                 "magento/module-inventory-indexer": "*"
@@ -12637,11 +12536,11 @@
         },
         {
             "name": "magento/module-inventory-sales-admin-ui",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-admin-ui-1.2.5.zip",
-                "shasum": "120746743818c1e42688643f8cbd7bb3d15d469b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-admin-ui-1.2.6.zip",
+                "shasum": "64ae450de764ba1a6512dbfaedc3307375c66ff0"
             },
             "require": {
                 "magento/framework": "*",
@@ -12655,7 +12554,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-sales": "*"
@@ -12677,17 +12576,17 @@
         },
         {
             "name": "magento/module-inventory-sales-api",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-api-1.2.4.zip",
-                "shasum": "cc2232f923c018d5b280c0dc4d70cd97df2b4e80"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-api-1.2.5.zip",
+                "shasum": "0e4c59f6cca21c94e238960187e27f21f4fd73e3"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-sales": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12706,11 +12605,11 @@
         },
         {
             "name": "magento/module-inventory-sales-async-order",
-            "version": "100.2.1",
+            "version": "100.2.2",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-async-order-100.2.1.zip",
-                "shasum": "0563e9d76e93d16773e9de8e67d5d50924d81bba"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-async-order-100.2.2.zip",
+                "shasum": "008efefe0948a31a46cf14483f7f582468e7dc5f"
             },
             "require": {
                 "magento/framework": "*",
@@ -12720,7 +12619,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-quote": "*",
                 "magento/module-sales": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-async-order": "*"
@@ -12742,11 +12641,11 @@
         },
         {
             "name": "magento/module-inventory-sales-frontend-ui",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-frontend-ui-1.2.4.zip",
-                "shasum": "d08bedc753deba0274f28f85dff274cf61023e9b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-sales-frontend-ui-1.2.5.zip",
+                "shasum": "8c09bb78b16e779cd446921f46716d7b799c002d"
             },
             "require": {
                 "magento/framework": "*",
@@ -12754,7 +12653,7 @@
                 "magento/module-inventory-catalog-frontend-ui": "1.0.*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12773,15 +12672,15 @@
         },
         {
             "name": "magento/module-inventory-setup-fixture-generator",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-setup-fixture-generator-1.2.3.zip",
-                "shasum": "9ebc05f37a50c80fe9c8fbea08e33fd8eb46f45c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-setup-fixture-generator-1.2.4.zip",
+                "shasum": "aeb0f0cfcdf796247b85c42fcdb07314b8d0f6d8"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12800,11 +12699,11 @@
         },
         {
             "name": "magento/module-inventory-shipping",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-shipping-1.2.4.zip",
-                "shasum": "31f85f2cbbcb7d688ef00ae4078355b9f0cd47ee"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-shipping-1.2.5.zip",
+                "shasum": "b9d56398ebc0ee9eda9bbbeba2fab9620f22b239"
             },
             "require": {
                 "magento/framework": "*",
@@ -12816,7 +12715,7 @@
                 "magento/module-sales": "*",
                 "magento/module-shipping": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12835,11 +12734,11 @@
         },
         {
             "name": "magento/module-inventory-shipping-admin-ui",
-            "version": "1.2.5",
+            "version": "1.2.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-shipping-admin-ui-1.2.5.zip",
-                "shasum": "c4ab22549c8c241a18032ccb007b36aa9a9091b9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-shipping-admin-ui-1.2.6.zip",
+                "shasum": "a0e55deec2d0f6666ae1968c1649b9a06f92a5de"
             },
             "require": {
                 "magento/framework": "*",
@@ -12851,7 +12750,7 @@
                 "magento/module-sales": "*",
                 "magento/module-shipping": "*",
                 "magento/module-ui": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12870,11 +12769,11 @@
         },
         {
             "name": "magento/module-inventory-source-deduction-api",
-            "version": "1.2.4",
+            "version": "1.2.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-deduction-api-1.2.4.zip",
-                "shasum": "e3cfed1a2d2bc98ce7ae0acafe9b4f2ce98dbc7d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-deduction-api-1.2.5.zip",
+                "shasum": "dfbdf701895d8fc8e7f3e152aad685672837a571"
             },
             "require": {
                 "magento/framework": "*",
@@ -12882,7 +12781,7 @@
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-configuration-api": "1.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12901,17 +12800,17 @@
         },
         {
             "name": "magento/module-inventory-source-selection",
-            "version": "1.2.3",
+            "version": "1.2.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-selection-1.2.3.zip",
-                "shasum": "386d5987a8d9f0c63a9b7961581db76538665b54"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-selection-1.2.4.zip",
+                "shasum": "9b215bb7d61c1b360f76598c6869df7f036c0c8a"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-inventory-api": "1.2.*",
                 "magento/module-inventory-source-selection-api": "1.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12930,11 +12829,11 @@
         },
         {
             "name": "magento/module-inventory-source-selection-api",
-            "version": "1.4.4",
+            "version": "1.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-selection-api-1.4.4.zip",
-                "shasum": "c6a8f12f4b0dd59971bbe75f92b2c69ef709f744"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-source-selection-api-1.4.5.zip",
+                "shasum": "df473f37f0652924570e69b5cb7c11d558fec58d"
             },
             "require": {
                 "magento/framework": "*",
@@ -12942,7 +12841,7 @@
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-sales": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -12961,15 +12860,15 @@
         },
         {
             "name": "magento/module-inventory-swatches-frontend-ui",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-swatches-frontend-ui-1.0.3.zip",
-                "shasum": "84bd3202920d5db7ddcafe1a6aaae672a8886ff7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-swatches-frontend-ui-1.0.4.zip",
+                "shasum": "d403721d7f728561fdd08d2d0e72bef7e8bf6de1"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-configurable-product-frontend-ui": "1.0.*",
@@ -12992,11 +12891,11 @@
         },
         {
             "name": "magento/module-inventory-visual-merchandiser",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-visual-merchandiser-1.1.5.zip",
-                "shasum": "de1838f51b841dfdecc62b45e2e507c664448f66"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-visual-merchandiser-1.1.6.zip",
+                "shasum": "77756266adaa7424d18f6367fbc22ae25288dab1"
             },
             "require": {
                 "magento/framework": "*",
@@ -13006,7 +12905,7 @@
                 "magento/module-inventory-indexer": "2.2.*",
                 "magento/module-inventory-sales-api": "1.2.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "require-dev": {
                 "magento/module-inventory-api": "*",
@@ -13032,15 +12931,15 @@
         },
         {
             "name": "magento/module-inventory-wishlist",
-            "version": "1.0.4",
+            "version": "1.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-wishlist-1.0.4.zip",
-                "shasum": "e7073038e5c35c073b3716b66f670f699befbaad"
+                "url": "https://mirror.mage-os.org/packages/magento/module-inventory-wishlist-1.0.5.zip",
+                "shasum": "a3752d42709ed3d9cd04b7658c0d3f0832a1f422"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory": "1.2.*",
@@ -13063,15 +12962,15 @@
         },
         {
             "name": "magento/module-jwt-framework-adapter",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-jwt-framework-adapter-100.4.3.zip",
-                "shasum": "c351a63fa2d8ff00fa6185a93c245142d7bf60f9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-jwt-framework-adapter-100.4.4.zip",
+                "shasum": "2497c96d46bbf559ba87bd0b82669b04228d7013"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "web-token/jwt-framework": "^3.1.2"
             },
             "type": "magento2-module",
@@ -13091,17 +12990,17 @@
         },
         {
             "name": "magento/module-jwt-user-token",
-            "version": "100.4.2-p2",
+            "version": "100.4.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-jwt-user-token-100.4.2-p2.zip",
-                "shasum": "468bc69cad6a2347d29e0602b36f1d56b038b055"
+                "url": "https://mirror.mage-os.org/packages/magento/module-jwt-user-token-100.4.3.zip",
+                "shasum": "90129ad831830352ce7beb5c61b983fa62fef5cd"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-authorization": "100.4.*",
                 "magento/module-integration": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13120,17 +13019,17 @@
         },
         {
             "name": "magento/module-layered-navigation",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-layered-navigation-100.4.7.zip",
-                "shasum": "156ba5e371bc1abf1b93ce438d75c380d7f77cd4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-layered-navigation-100.4.8.zip",
+                "shasum": "4310ec8cdb112b13679a1ad7f624bb01525d98a9"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-config": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13149,18 +13048,18 @@
         },
         {
             "name": "magento/module-login-as-customer",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-100.4.7.zip",
-                "shasum": "f8ebf0dce90781d94c3d70252ae834b7c1c963d8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-100.4.8.zip",
+                "shasum": "fa50e0c02c7c23eda0a2a4caf820e8083a750952"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-login-as-customer-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-backend": "102.0.*"
@@ -13182,11 +13081,11 @@
         },
         {
             "name": "magento/module-login-as-customer-admin-ui",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-admin-ui-100.4.7.zip",
-                "shasum": "18a1e6fd679d34733e5010dd8d17d45af5204167"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-admin-ui-100.4.8.zip",
+                "shasum": "21cf75709fc07ced9a6fb9d5d9a60f74aaa76416"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13196,7 +13095,7 @@
                 "magento/module-login-as-customer-frontend-ui": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer": "100.4.*"
@@ -13217,15 +13116,15 @@
         },
         {
             "name": "magento/module-login-as-customer-api",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-api-100.4.6.zip",
-                "shasum": "bc53b3e25c73bfcd661f524d414d2d6761344b4e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-api-100.4.7.zip",
+                "shasum": "fae7b8eabfd1e2f18404d79a800b050fec394b30"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13244,11 +13143,11 @@
         },
         {
             "name": "magento/module-login-as-customer-assistance",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-assistance-100.4.6.zip",
-                "shasum": "938f89d82c51463c9963feb4ad3c02b05e52a778"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-assistance-100.4.7.zip",
+                "shasum": "f771996d186f79e5416de33ee4e80f503d35852a"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13258,7 +13157,7 @@
                 "magento/module-login-as-customer": "100.4.*",
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer-admin-ui": "100.4.*"
@@ -13279,18 +13178,18 @@
         },
         {
             "name": "magento/module-login-as-customer-frontend-ui",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-frontend-ui-100.4.6.zip",
-                "shasum": "8449cf9b86e646b15c6f744733366cb0c3a4d8b7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-frontend-ui-100.4.7.zip",
+                "shasum": "050b7b71ee61f34da2bb9d0fc4d9ab2e5cfb750a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13308,11 +13207,11 @@
         },
         {
             "name": "magento/module-login-as-customer-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-graph-ql-100.4.4.zip",
-                "shasum": "c72b74e13eb1387c26ec9fb304a0bb1e29fea6cb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-graph-ql-100.4.5.zip",
+                "shasum": "9d045728d605d0f5433d749c57550c4d69ee3668"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13321,7 +13220,7 @@
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-login-as-customer-assistance": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer": "100.4.*"
@@ -13343,11 +13242,11 @@
         },
         {
             "name": "magento/module-login-as-customer-log",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-log-100.4.5.zip",
-                "shasum": "a1bfec5b5424c67c0789195e49966e822c3ada21"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-log-100.4.6.zip",
+                "shasum": "cba514e11d1dfe4331454f1440963a82502856c3"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13356,7 +13255,7 @@
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer": "100.4.*"
@@ -13377,17 +13276,17 @@
         },
         {
             "name": "magento/module-login-as-customer-page-cache",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-page-cache-100.4.6.zip",
-                "shasum": "a7c54cb4bff30f2a813ddeaf88954620927f62a3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-page-cache-100.4.7.zip",
+                "shasum": "b0b908d442145542597792b80e979695019e3ebe"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-page-cache": "100.4.*"
@@ -13408,18 +13307,18 @@
         },
         {
             "name": "magento/module-login-as-customer-quote",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-quote-100.4.5.zip",
-                "shasum": "17892784a4cfc684df867a597102f86b5f07511e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-quote-100.4.6.zip",
+                "shasum": "110ca39cb4603c1ab7d3ff3cf8e159bbc9e3f34a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer-api": "100.4.*"
@@ -13440,18 +13339,18 @@
         },
         {
             "name": "magento/module-login-as-customer-sales",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-sales-100.4.6.zip",
-                "shasum": "130174a2ca45b247a404bf1f3f7eaf877b450726"
+                "url": "https://mirror.mage-os.org/packages/magento/module-login-as-customer-sales-100.4.7.zip",
+                "shasum": "73ec39806eabac86977477b4de6a8393e8c21c85"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-login-as-customer-api": "100.4.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-sales": "103.0.*"
@@ -13472,16 +13371,16 @@
         },
         {
             "name": "magento/module-marketplace",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-marketplace-100.4.5.zip",
-                "shasum": "bb6e0a92aa32c09b05afe17ee8b945efba12f3c5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-marketplace-100.4.6.zip",
+                "shasum": "174c5af7ef6d48ad722c8f08bc2ea924c66b389f"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13500,17 +13399,17 @@
         },
         {
             "name": "magento/module-media-content",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-100.4.5.zip",
-                "shasum": "640d1b2bedb6e9a6ac7b1aff7bad171a93578e53"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-100.4.6.zip",
+                "shasum": "78c0839a81559c4628bdeb14c066855e4bbcfdec"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-content-api": "100.4.*",
                 "magento/module-media-gallery-api": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13529,16 +13428,16 @@
         },
         {
             "name": "magento/module-media-content-api",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-api-100.4.6.zip",
-                "shasum": "6b47d252aad5dfeca480bb6961516465aa8d71a0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-api-100.4.7.zip",
+                "shasum": "829799457e2d349941e28ecbaa15bdde617435e8"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13557,11 +13456,11 @@
         },
         {
             "name": "magento/module-media-content-catalog",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-catalog-100.4.5.zip",
-                "shasum": "ad107d0cd29c0852186e3fcd1100e8192ac6adea"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-catalog-100.4.6.zip",
+                "shasum": "2b44c4e601283f3c477e94881a58ada091cb962b"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13569,7 +13468,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-media-content-api": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13588,17 +13487,17 @@
         },
         {
             "name": "magento/module-media-content-cms",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-cms-100.4.5.zip",
-                "shasum": "cf0efcc15b45211c090740f22b8e7b1af71d6dd9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-cms-100.4.6.zip",
+                "shasum": "14f0a80ad3132dbc1a60083443c2990e429e2493"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-cms": "104.0.*",
                 "magento/module-media-content-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13617,11 +13516,11 @@
         },
         {
             "name": "magento/module-media-content-synchronization",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-100.4.6.zip",
-                "shasum": "ecd221fb1ecddda3bda76da590a9d98428c92c1b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-100.4.7.zip",
+                "shasum": "1ebc231de456a11a5f43463af7bd73b9548d5470"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13629,7 +13528,7 @@
                 "magento/module-asynchronous-operations": "100.4.*",
                 "magento/module-media-content-api": "100.4.*",
                 "magento/module-media-content-synchronization-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-media-gallery-synchronization": "100.4.*"
@@ -13651,16 +13550,16 @@
         },
         {
             "name": "magento/module-media-content-synchronization-api",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-api-100.4.5.zip",
-                "shasum": "0e50eb2fc04c7974958e578b1d4a226a72547ef0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-api-100.4.6.zip",
+                "shasum": "1d46933f54499bb97cc787d979d72a04635d5771"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-content-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13679,18 +13578,18 @@
         },
         {
             "name": "magento/module-media-content-synchronization-catalog",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-catalog-100.4.4.zip",
-                "shasum": "60023fd7de5923e3ca8f36c80ed346be4c1a7620"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-catalog-100.4.5.zip",
+                "shasum": "d279e31e474a74ad839bd3fbdecb6b7ae5e3f341"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-content-api": "100.4.*",
                 "magento/module-media-content-synchronization-api": "100.4.*",
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13709,18 +13608,18 @@
         },
         {
             "name": "magento/module-media-content-synchronization-cms",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-cms-100.4.4.zip",
-                "shasum": "d8458effcb51af4ab1d79bb657337b9d34f1c7d7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-content-synchronization-cms-100.4.5.zip",
+                "shasum": "453dffeac8aaf39789bb939262424f0ce17393dc"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-content-api": "100.4.*",
                 "magento/module-media-content-synchronization-api": "100.4.*",
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13739,17 +13638,17 @@
         },
         {
             "name": "magento/module-media-gallery",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-100.4.6.zip",
-                "shasum": "f581e8847e5ba6a5f770ddf8973b0c0ee4da4b0d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-100.4.7.zip",
+                "shasum": "a01daa5ba825c3cea1c7518acb88a0bba82acfb5"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-cms": "104.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13768,15 +13667,15 @@
         },
         {
             "name": "magento/module-media-gallery-api",
-            "version": "101.0.6",
+            "version": "101.0.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-api-101.0.6.zip",
-                "shasum": "8a262a334e479870f53d76145f1f314cb82e9680"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-api-101.0.7.zip",
+                "shasum": "509dd622cf9719da1dece2dd19d2a758df3842ce"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13795,17 +13694,17 @@
         },
         {
             "name": "magento/module-media-gallery-catalog",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-100.4.4.zip",
-                "shasum": "0ad015ee880ae410b1e1fe68905894668e26a57d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-100.4.5.zip",
+                "shasum": "e10615afa0fd8b99ef8a8d3cb9d5900d085a7909"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13824,11 +13723,11 @@
         },
         {
             "name": "magento/module-media-gallery-catalog-integration",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-integration-100.4.4.zip",
-                "shasum": "631bd086b13b742f8f72d5d9e417f83779f08dd1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-integration-100.4.5.zip",
+                "shasum": "6af8cbcdd830b1b3327b7416886884b3d8b29b59"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13836,7 +13735,7 @@
                 "magento/module-media-gallery-api": "101.0.*",
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
                 "magento/module-media-gallery-ui-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog": "104.0.*"
@@ -13858,11 +13757,11 @@
         },
         {
             "name": "magento/module-media-gallery-catalog-ui",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-ui-100.4.4.zip",
-                "shasum": "f1523291fb0332384b399775f7e7e221f07ae6e6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-catalog-ui-100.4.5.zip",
+                "shasum": "c9ebaa3cc1dbea6a08645ffab64ccb3032fa4080"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13871,7 +13770,7 @@
                 "magento/module-cms": "104.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13890,17 +13789,17 @@
         },
         {
             "name": "magento/module-media-gallery-cms-ui",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-cms-ui-100.4.4.zip",
-                "shasum": "dfb96beac80a2ed7d44a1cf26341bedfb1cca8e3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-cms-ui-100.4.5.zip",
+                "shasum": "1600ea901be3f6f955ffba679a8ef4379be0890a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-cms": "104.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13919,11 +13818,11 @@
         },
         {
             "name": "magento/module-media-gallery-integration",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-integration-100.4.6.zip",
-                "shasum": "288307d0cb8fcf22e6049bf6f9e307d416a9f62b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-integration-100.4.7.zip",
+                "shasum": "b275cac8aaa31d7f6bf273e1beb49cc387e4e3b8"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -13931,7 +13830,7 @@
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
                 "magento/module-media-gallery-ui-api": "100.4.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "require-dev": {
                 "magento/module-cms": "*"
@@ -13957,16 +13856,16 @@
         },
         {
             "name": "magento/module-media-gallery-metadata",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-metadata-100.4.5.zip",
-                "shasum": "f6685468631fdf6b2fe8528b3ba36ae5ea2a5450"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-metadata-100.4.6.zip",
+                "shasum": "d31d87586844cf5186a088745993f1aa184de58d"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-gallery-metadata-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -13985,15 +13884,15 @@
         },
         {
             "name": "magento/module-media-gallery-metadata-api",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-metadata-api-100.4.4.zip",
-                "shasum": "7fd55f49427c214d7ce8e0f1e3e162672b053326"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-metadata-api-100.4.5.zip",
+                "shasum": "a78db8239b492d1a38554e493714028fbadc68e4"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14012,11 +13911,11 @@
         },
         {
             "name": "magento/module-media-gallery-renditions",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-renditions-100.4.5.zip",
-                "shasum": "25c8d616d3d744b3be3d640227f0368c2b48676a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-renditions-100.4.6.zip",
+                "shasum": "c9cbb30aeca92bb9c8ebc5609f6f2ed3b2c5425d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14024,7 +13923,7 @@
                 "magento/module-cms": "104.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
                 "magento/module-media-gallery-renditions-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-media-content-api": "100.4.*"
@@ -14046,15 +13945,15 @@
         },
         {
             "name": "magento/module-media-gallery-renditions-api",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-renditions-api-100.4.4.zip",
-                "shasum": "ef3b1260d0efac2e8be82693663f21364a42b365"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-renditions-api-100.4.5.zip",
+                "shasum": "52eb5d35405f2307c75f542442cef124a21d1863"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14073,18 +13972,18 @@
         },
         {
             "name": "magento/module-media-gallery-synchronization",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-100.4.6.zip",
-                "shasum": "9c4d05aca980dabefc240b50a9a790ecbab95602"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-100.4.7.zip",
+                "shasum": "0d1bc7fcf9222cebfc385fa2ae1b9159437205d3"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/framework-message-queue": "100.4.*",
                 "magento/module-media-gallery-api": "101.0.*",
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14103,16 +14002,16 @@
         },
         {
             "name": "magento/module-media-gallery-synchronization-api",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-api-100.4.5.zip",
-                "shasum": "15ad013d0325dbbeb767b8a867ab9180857e8d12"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-api-100.4.6.zip",
+                "shasum": "8dd343ee68dbeddabbf565e14a0711d0e32bbdb2"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14131,18 +14030,18 @@
         },
         {
             "name": "magento/module-media-gallery-synchronization-metadata",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-metadata-100.4.3.zip",
-                "shasum": "2af85ea42132a9fc7b407986a33745132ff767c7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-synchronization-metadata-100.4.4.zip",
+                "shasum": "81d70be3843f5b190092336a337b528c9d2b8b97"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-media-gallery-api": "101.0.*",
                 "magento/module-media-gallery-metadata-api": "100.4.*",
                 "magento/module-media-gallery-synchronization-api": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14161,11 +14060,11 @@
         },
         {
             "name": "magento/module-media-gallery-ui",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-ui-100.4.6.zip",
-                "shasum": "b460ee5cc5729b159befc8385b9f7040518c0077"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-ui-100.4.7.zip",
+                "shasum": "7a79ab4f084cb450a7deb42f8dc3094de97f5958"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14180,7 +14079,7 @@
                 "magento/module-media-gallery-ui-api": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14199,15 +14098,15 @@
         },
         {
             "name": "magento/module-media-gallery-ui-api",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-ui-api-100.4.5.zip",
-                "shasum": "f2317f3da51732a2ecce1e09a3e6af243d049b5b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-gallery-ui-api-100.4.6.zip",
+                "shasum": "b85beef0d6b1604dd92e930ca58c9bdaf6bfa172"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cms": "104.0.*"
@@ -14229,11 +14128,11 @@
         },
         {
             "name": "magento/module-media-storage",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-media-storage-100.4.6.zip",
-                "shasum": "06a8e2cd3b709b37df2d6fa229c577119215db61"
+                "url": "https://mirror.mage-os.org/packages/magento/module-media-storage-100.4.7.zip",
+                "shasum": "cfa03b3b8810ea9d5adee8b4fd3db102e342df35"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14245,7 +14144,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14264,17 +14163,17 @@
         },
         {
             "name": "magento/module-message-queue",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-message-queue-100.4.7.zip",
-                "shasum": "f68a8b625ca35c06cef8d7171ebc6781e4ca36f3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-message-queue-100.4.8.zip",
+                "shasum": "335594ce18fea464b225507bf4205f34c236b5c0"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/framework-message-queue": "100.4.*",
                 "magento/magento-composer-installer": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14293,11 +14192,11 @@
         },
         {
             "name": "magento/module-msrp",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-100.4.6.zip",
-                "shasum": "e4a11f512c5f0a25d86a25d08800e4770693cfed"
+                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-100.4.7.zip",
+                "shasum": "f6ec8f7214e9d959f21f9aeac7900654183f306b"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14306,7 +14205,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-bundle": "101.0.*",
@@ -14329,18 +14228,18 @@
         },
         {
             "name": "magento/module-msrp-configurable-product",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-configurable-product-100.4.4.zip",
-                "shasum": "45768a5ecf602fc35d0fef3406d449a1e485518f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-configurable-product-100.4.5.zip",
+                "shasum": "a67f73dc195467f1732eb6911498cafb400a8f8a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-configurable-product": "100.4.*",
                 "magento/module-msrp": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14359,18 +14258,18 @@
         },
         {
             "name": "magento/module-msrp-grouped-product",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-grouped-product-100.4.4.zip",
-                "shasum": "11447ba1e7b3e3f0f35cfb57eedf37810b4eff33"
+                "url": "https://mirror.mage-os.org/packages/magento/module-msrp-grouped-product-100.4.5.zip",
+                "shasum": "9862e9401eca27d82ad3d67d191abcf9e223e23a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-grouped-product": "100.4.*",
                 "magento/module-msrp": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14389,11 +14288,11 @@
         },
         {
             "name": "magento/module-multishipping",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-multishipping-100.4.7.zip",
-                "shasum": "3a4834642fda2a35c030ddbb27043e4318b0d949"
+                "url": "https://mirror.mage-os.org/packages/magento/module-multishipping-100.4.8.zip",
+                "shasum": "4d1451c1b5d95b73d3fe37cbbf6eac1fa4713155"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14407,7 +14306,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14426,18 +14325,18 @@
         },
         {
             "name": "magento/module-mysql-mq",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-mysql-mq-100.4.5.zip",
-                "shasum": "26fb398f7df9b930568456feb41f70532aedbd36"
+                "url": "https://mirror.mage-os.org/packages/magento/module-mysql-mq-100.4.6.zip",
+                "shasum": "c826e2d25c673c1046f23a5d01e5e4ee9b281123"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/framework-message-queue": "100.4.*",
                 "magento/magento-composer-installer": "*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14456,11 +14355,11 @@
         },
         {
             "name": "magento/module-new-relic-reporting",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-new-relic-reporting-100.4.5.zip",
-                "shasum": "321b5bb1189567d2c09833de3beb59b58f5aff2c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-new-relic-reporting-100.4.6.zip",
+                "shasum": "4996410c121dcc91863a01f3ef0789093057210b"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14471,7 +14370,7 @@
                 "magento/module-configurable-product": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14490,11 +14389,11 @@
         },
         {
             "name": "magento/module-newsletter",
-            "version": "100.4.7-p2",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-newsletter-100.4.7-p2.zip",
-                "shasum": "167a6fa974b6cc96881e2b8894a08471df4c1c3a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-newsletter-100.4.8.zip",
+                "shasum": "0da4c13e4e3b1e26c3a0ac5bc492a96ab5ee1540"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14507,7 +14406,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-widget": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14526,11 +14425,11 @@
         },
         {
             "name": "magento/module-newsletter-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-newsletter-graph-ql-100.4.4.zip",
-                "shasum": "70f15920b2cb433a92e199ed93048dffff23c2aa"
+                "url": "https://mirror.mage-os.org/packages/magento/module-newsletter-graph-ql-100.4.5.zip",
+                "shasum": "1cfae8cf30e95c3d53a972ba633532535c9a4a34"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14539,7 +14438,7 @@
                 "magento/module-graph-ql-resolver-cache": "100.4.*",
                 "magento/module-newsletter": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14558,18 +14457,18 @@
         },
         {
             "name": "magento/module-offline-payments",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-offline-payments-100.4.5.zip",
-                "shasum": "52afadff81e795a86ffbdc07361b910640b29994"
+                "url": "https://mirror.mage-os.org/packages/magento/module-offline-payments-100.4.6.zip",
+                "shasum": "ef710ea828fe3418ff406d0ba996b3154f8e2412"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-payment": "100.4.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -14591,11 +14490,11 @@
         },
         {
             "name": "magento/module-offline-shipping",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-offline-shipping-100.4.6.zip",
-                "shasum": "9f2e2b1c935dd23a04f82d3afc1af4c5442e194d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-offline-shipping-100.4.7.zip",
+                "shasum": "a5bb50b6cb1dfe729b817cfb2120b95a80024856"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14609,7 +14508,7 @@
                 "magento/module-sales-rule": "101.2.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-checkout": "100.4.*",
@@ -14632,11 +14531,11 @@
         },
         {
             "name": "magento/module-open-search",
-            "version": "100.4.1",
+            "version": "100.4.2",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-open-search-100.4.1.zip",
-                "shasum": "e3b19840abdd0a6f195b50d487b5100654775702"
+                "url": "https://mirror.mage-os.org/packages/magento/module-open-search-100.4.2.zip",
+                "shasum": "ea89574bf618eaa0d6db2f717b4292052932a3cb"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14645,8 +14544,8 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-elasticsearch": "101.0.*",
                 "magento/module-search": "101.1.*",
-                "opensearch-project/opensearch-php": "^1.0 || ^2.0",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "opensearch-project/opensearch-php": "^2.3",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14665,18 +14564,18 @@
         },
         {
             "name": "magento/module-order-cancellation",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-100.4.0.zip",
-                "shasum": "08a0d45dd49474ecc5a3a55e38846429ffae0369"
+                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-100.4.1.zip",
+                "shasum": "121be6e27799e3bc6033a6c409df9ae1e7a32bf7"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-config": "101.2.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14695,18 +14594,19 @@
         },
         {
             "name": "magento/module-order-cancellation-graph-ql",
-            "version": "100.4.0",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-graph-ql-100.4.0.zip",
-                "shasum": "68ad2736fc1a0a4f05ef62739f3d98f7085d42c8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-graph-ql-100.4.1.zip",
+                "shasum": "210e3c49821615a216045ab1abfdc9f21b2b1d74"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-order-cancellation": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-sales-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "magento/module-store": "101.1.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14725,18 +14625,18 @@
         },
         {
             "name": "magento/module-order-cancellation-ui",
-            "version": "100.4.0-p4",
+            "version": "100.4.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-ui-100.4.0-p4.zip",
-                "shasum": "dba95e1c73d23123a8e8585bb3ad83e60aa1481e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-order-cancellation-ui-100.4.1.zip",
+                "shasum": "f801f200d0410693db38f1f6565ba489b584523d"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-order-cancellation": "100.4.*",
                 "magento/module-sales": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14755,40 +14655,40 @@
         },
         {
             "name": "magento/module-page-builder",
-            "version": "2.2.5-p4",
+            "version": "2.2.6-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-2.2.5-p4.zip",
-                "shasum": "a2d5adcb1b6dae8341b4a299b8a59a3fff7422f9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-2.2.6-p1.zip",
+                "shasum": "22ce4bc8770773a30766b3a50bab8616baf5ff03"
             },
             "require": {
-                "magento/framework": "*",
-                "magento/module-backend": "*",
-                "magento/module-catalog": "*",
-                "magento/module-catalog-inventory": "*",
-                "magento/module-catalog-widget": "*",
-                "magento/module-cms": "*",
-                "magento/module-config": "*",
-                "magento/module-directory": "*",
-                "magento/module-eav": "*",
-                "magento/module-email": "*",
-                "magento/module-media-storage": "*",
-                "magento/module-require-js": "*",
-                "magento/module-rule": "*",
-                "magento/module-store": "*",
-                "magento/module-theme": "*",
-                "magento/module-ui": "*",
-                "magento/module-variable": "*",
-                "magento/module-widget": "*",
-                "magento/module-wishlist": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "magento/framework": "103.0.*",
+                "magento/module-backend": "102.0.*",
+                "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-inventory": "100.4.*",
+                "magento/module-catalog-widget": "100.4.*",
+                "magento/module-cms": "104.0.*",
+                "magento/module-config": "101.2.*",
+                "magento/module-directory": "100.4.*",
+                "magento/module-eav": "102.1.*",
+                "magento/module-email": "101.1.*",
+                "magento/module-media-storage": "100.4.*",
+                "magento/module-require-js": "100.4.*",
+                "magento/module-rule": "100.4.*",
+                "magento/module-store": "101.1.*",
+                "magento/module-theme": "101.1.*",
+                "magento/module-ui": "101.2.*",
+                "magento/module-variable": "100.4.*",
+                "magento/module-widget": "101.2.*",
+                "magento/module-wishlist": "101.2.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "phpgt/dom": "^4.1"
             },
             "conflict": {
                 "gene/bluefoot": "*"
             },
             "suggest": {
-                "magento/module-review": "*"
+                "magento/module-review": "100.4.*"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14806,15 +14706,15 @@
         },
         {
             "name": "magento/module-page-builder-admin-analytics",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-admin-analytics-1.1.4.zip",
-                "shasum": "500ef457e183425c619274f6196b1df346b97fe3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-admin-analytics-1.1.5.zip",
+                "shasum": "b89ea1888fbe5bd848c6a857b76d1fd6a55fb275"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-admin-analytics": "*",
@@ -14836,17 +14736,17 @@
         },
         {
             "name": "magento/module-page-builder-analytics",
-            "version": "1.6.4",
+            "version": "1.6.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-analytics-1.6.4.zip",
-                "shasum": "3ca83728034d3f0aca1ff14069292cf9e5b63e74"
+                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-analytics-1.6.5.zip",
+                "shasum": "66d826a33cdc002b3392a4a3db6c058f525cc7f9"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-analytics": "*",
                 "magento/module-page-builder": "2.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14863,12 +14763,38 @@
             "description": "Page Builder Analytics module"
         },
         {
-            "name": "magento/module-page-cache",
-            "version": "100.4.7",
+            "name": "magento/module-page-builder-image-attribute",
+            "version": "1.7.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-page-cache-100.4.7.zip",
-                "shasum": "e63079b701311a3ff494aa8b2dc23dfc91f7a37c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-page-builder-image-attribute-1.7.5.zip",
+                "shasum": "4720d51eddf74761a917f44d67271ba4d9358f1f"
+            },
+            "require": {
+                "magento/framework": "*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\PageBuilderImageAttribute\\": ""
+                }
+            },
+            "license": [
+                "proprietary"
+            ],
+            "description": "Width & Height attribute - Pagebuilder image"
+        },
+        {
+            "name": "magento/module-page-cache",
+            "version": "100.4.8",
+            "dist": {
+                "type": "zip",
+                "url": "https://mirror.mage-os.org/packages/magento/module-page-cache-100.4.8.zip",
+                "shasum": "3b2d2a84cb315848ede53150313c563a2003a2c3"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14876,7 +14802,7 @@
                 "magento/module-catalog": "104.0.*",
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14895,11 +14821,11 @@
         },
         {
             "name": "magento/module-payment",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-payment-100.4.7.zip",
-                "shasum": "28118ad5cf6c3c60d237617b21a48c54c0b531a6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-payment-100.4.8.zip",
+                "shasum": "73200ccce06702608369ccef7b5ef7194fad1c5f"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -14910,7 +14836,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -14929,17 +14855,17 @@
         },
         {
             "name": "magento/module-payment-graph-ql",
-            "version": "100.4.2",
+            "version": "100.4.3",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-payment-graph-ql-100.4.2.zip",
-                "shasum": "d160204bfae99c242f22adb018bbf085768f816a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-payment-graph-ql-100.4.3.zip",
+                "shasum": "b35f63272cd9bdff30c304ef798bf51d8df1d61b"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-payment": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-store-graph-ql": "100.4.*"
@@ -14961,11 +14887,11 @@
         },
         {
             "name": "magento/module-payment-services-base",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-base-2.10.1.0.zip",
-                "shasum": "908fe30634a5d7f188a37af8b774b9483be106fd"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-base-2.11.1.0.zip",
+                "shasum": "5de35a2a871b004cec1c7ea3520e3bb8422d4066"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
@@ -14973,10 +14899,10 @@
                 "magento/module-config": ">=101.2.4 <102.0.0",
                 "magento/module-directory": ">=100.4.4 <101.0.0",
                 "magento/module-payment": ">=100.4.4 <101.0.0",
-                "magento/module-payment-services-dashboard": "2.10.1",
-                "magento/module-payment-services-paypal": "2.10.1",
+                "magento/module-payment-services-dashboard": "2.11.1",
+                "magento/module-payment-services-paypal": "2.11.1",
                 "magento/module-sales": ">=103.0.4 <104.0.0",
-                "magento/module-service-proxy": "2.10.1",
+                "magento/module-service-proxy": "2.11.1",
                 "magento/module-services-id": "^3.2.0",
                 "magento/module-services-id-graph-ql-server": "^1.1.0",
                 "magento/module-services-id-layout": "^1.1.0",
@@ -15005,20 +14931,20 @@
         },
         {
             "name": "magento/module-payment-services-dashboard",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-dashboard-2.10.1.0.zip",
-                "shasum": "d73e85b2c61be51263df59b62641bbc24aae7fa2"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-dashboard-2.11.1.0.zip",
+                "shasum": "09aafa32ef8a1052474a0c0a3fb4fa82a27d281d"
             },
             "require": {
                 "ext-json": "*",
                 "magento/framework": ">=103.0.4 <104.0.0",
                 "magento/module-backend": ">=102.0.4 <103.0.0",
                 "magento/module-config": ">=101.2.4 <102.0.0",
-                "magento/module-payment-services-base": "2.10.1",
-                "magento/module-payment-services-paypal": "2.10.1",
-                "magento/module-service-proxy": "2.10.1",
+                "magento/module-payment-services-base": "2.11.1",
+                "magento/module-payment-services-paypal": "2.11.1",
+                "magento/module-service-proxy": "2.11.1",
                 "magento/module-store": ">=101.1.4 <102.0.0",
                 "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
@@ -15039,11 +14965,11 @@
         },
         {
             "name": "magento/module-payment-services-paypal",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-paypal-2.10.1.0.zip",
-                "shasum": "b150aed0c864ee7aa87c7be0212641a7293a070e"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-paypal-2.11.1.0.zip",
+                "shasum": "19401bf9d9e3690febe8c38bcb72ddabeb8b349a"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
@@ -15058,12 +14984,12 @@
                 "magento/module-instant-purchase": ">=100.4.3 <101.0.0",
                 "magento/module-integration": ">=100.4.4 <101.0.0",
                 "magento/module-payment": ">=100.4.4 <101.0.0",
-                "magento/module-payment-services-base": "2.10.1",
+                "magento/module-payment-services-base": "2.11.1",
                 "magento/module-query-xml": "^103.0.3",
                 "magento/module-quote": ">=101.2.4 <102.0.0",
                 "magento/module-sales": ">=103.0.4 <104.0.0",
                 "magento/module-sales-rule": ">=101.2.4 <102.0.0",
-                "magento/module-service-proxy": "2.10.1",
+                "magento/module-service-proxy": "2.11.1",
                 "magento/module-store": ">=101.1.4 <102.0.0",
                 "magento/module-tax": ">=100.4.4 <101.0.0",
                 "magento/module-theme": ">=101.1.4 <102.0.0",
@@ -15087,15 +15013,15 @@
         },
         {
             "name": "magento/module-payment-services-paypal-graph-ql",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-paypal-graph-ql-2.10.1.0.zip",
-                "shasum": "0b2c840cd9d32e64f21764f5bf9d103eef87dd9e"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-paypal-graph-ql-2.11.1.0.zip",
+                "shasum": "216f3b8da755a349d0af1891343ef5059ef92cba"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
-                "magento/module-payment-services-paypal": "2.10.1",
+                "magento/module-payment-services-paypal": "2.11.1",
                 "magento/module-quote": ">=101.2.4 <102.0.0",
                 "magento/module-quote-graph-ql": ">=100.4.4 <101.0.0",
                 "magento/module-vault": ">=101.2.4 <102.0.0",
@@ -15118,20 +15044,20 @@
         },
         {
             "name": "magento/module-payment-services-saas-export",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-saas-export-2.10.1.0.zip",
-                "shasum": "5785f3e43f881f04d49155166f7240280efb81ce"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-payment-services-saas-export-2.11.1.0.zip",
+                "shasum": "a1ed6b5bf0aa3fc8495ba907d022a123dd332fea"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
                 "magento/module-data-exporter": "^103.0.3",
-                "magento/module-payment-services-base": "2.10.1",
+                "magento/module-payment-services-base": "2.11.1",
                 "magento/module-saas-common": "^103.0.3",
-                "magento/module-sales-data-exporter": "2.10.1",
+                "magento/module-sales-data-exporter": "2.11.1",
                 "magento/module-services-id": "^3.2.0",
-                "magento/module-store-data-exporter": "2.10.1",
+                "magento/module-store-data-exporter": "2.11.1",
                 "magento/services-connector": "^1.3.0",
                 "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
@@ -15152,11 +15078,11 @@
         },
         {
             "name": "magento/module-paypal",
-            "version": "101.0.7-p3",
+            "version": "101.0.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-101.0.7-p3.zip",
-                "shasum": "6f450e9ab24ee5a8a83dbe2d3cb4f40f6c4261bb"
+                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-101.0.8-p1.zip",
+                "shasum": "fbb5901f37d6d8291dd69c17ad69311937bcb03a"
             },
             "require": {
                 "lib-libxml": "*",
@@ -15179,7 +15105,7 @@
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-vault": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-checkout-agreements": "100.4.*"
@@ -15201,18 +15127,18 @@
         },
         {
             "name": "magento/module-paypal-captcha",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-captcha-100.4.4.zip",
-                "shasum": "d11822118c09bfc6710f1f7610d9f4cf1da6a4a6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-captcha-100.4.5.zip",
+                "shasum": "396217f8acfd2f7f7c8f594d8f72e1a6bef78397"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-captcha": "100.4.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-paypal": "101.0.*"
@@ -15234,11 +15160,11 @@
         },
         {
             "name": "magento/module-paypal-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-graph-ql-100.4.5.zip",
-                "shasum": "54db3f95613b78f1698240e4cb06707c37e75c15"
+                "url": "https://mirror.mage-os.org/packages/magento/module-paypal-graph-ql-100.4.6.zip",
+                "shasum": "bd8c309dcfc6f422b73bc8831ce4bcdff7832254"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -15250,7 +15176,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-vault": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*",
@@ -15273,11 +15199,11 @@
         },
         {
             "name": "magento/module-persistent",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-persistent-100.4.7.zip",
-                "shasum": "04ad793b1b62f5ebfda9320865f9310df41ed036"
+                "url": "https://mirror.mage-os.org/packages/magento/module-persistent-100.4.8.zip",
+                "shasum": "a91a2acab5e68dd0319d85048e9a774f29ac72df"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -15287,7 +15213,7 @@
                 "magento/module-page-cache": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-login-as-customer-api": "100.4.*"
@@ -15309,11 +15235,11 @@
         },
         {
             "name": "magento/module-product-alert",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-product-alert-100.4.6.zip",
-                "shasum": "4a6143cabb9f8036b102ff515a11c071d5d57f6a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-product-alert-100.4.7.zip",
+                "shasum": "55ec0e53c8c016aab75eff478fc1c95b40c43b74"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -15325,7 +15251,7 @@
                 "magento/module-customer": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -15347,11 +15273,11 @@
         },
         {
             "name": "magento/module-product-video",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-product-video-100.4.7.zip",
-                "shasum": "5b1f8da165ffdcd2ba46a1a5c1506c26e38d18f5"
+                "url": "https://mirror.mage-os.org/packages/magento/module-product-video-100.4.8.zip",
+                "shasum": "0ed8aaf2577bdacc7ef9f34fb969658e6e851552"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -15361,7 +15287,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*",
@@ -15385,11 +15311,11 @@
         },
         {
             "name": "magento/module-query-xml",
-            "version": "103.3.18",
+            "version": "103.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-query-xml-103.3.18.0.zip",
-                "shasum": "3129384ace59891077a25cfa404f752b6b1553bc"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-query-xml-103.4.5.0.zip",
+                "shasum": "3ac8f1f498e9ef7fd3515b72459a8f74c314cdfc"
             },
             "require": {
                 "magento/framework": ">=103.0.4",
@@ -15413,11 +15339,11 @@
         },
         {
             "name": "magento/module-quote",
-            "version": "101.2.7-p4",
+            "version": "101.2.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-101.2.7-p4.zip",
-                "shasum": "e9224b4b36c021b0d5a1ccf56f9ba6ae8396e795"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-101.2.8-p1.zip",
+                "shasum": "65c45eb6fcb0a58279738051944f1c50874cb58a"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -15435,7 +15361,7 @@
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-webapi": "100.4.*"
@@ -15457,17 +15383,17 @@
         },
         {
             "name": "magento/module-quote-analytics",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-analytics-100.4.6.zip",
-                "shasum": "f12a8545b8c26e1abb7c25b32e8b5a03d07f790c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-analytics-100.4.7.zip",
+                "shasum": "8d4b690ab78cb7f22abf45dee91e6f73bdd169fe"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15486,16 +15412,16 @@
         },
         {
             "name": "magento/module-quote-bundle-options",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-bundle-options-100.4.3.zip",
-                "shasum": "3fe6e93b598a91dc6c3fc9868fc1cc20bce79564"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-bundle-options-100.4.4.zip",
+                "shasum": "3c6a455dc4911f43b59c11b9c27003d75ed0ac5c"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15514,16 +15440,16 @@
         },
         {
             "name": "magento/module-quote-configurable-options",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-configurable-options-100.4.3.zip",
-                "shasum": "ab5815948b60a285bf5731607eeb84db33180e2e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-configurable-options-100.4.4.zip",
+                "shasum": "37174b754eb6759ae818071cf233ea29ea279d2c"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15542,16 +15468,16 @@
         },
         {
             "name": "magento/module-quote-downloadable-links",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-downloadable-links-100.4.3.zip",
-                "shasum": "f4b4c9b96767c18aca07ff9d1bac2098e3a265b7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-downloadable-links-100.4.4.zip",
+                "shasum": "e8502f0011fde617ffadbc9e01310753b63614f8"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-quote": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15570,28 +15496,32 @@
         },
         {
             "name": "magento/module-quote-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-quote-graph-ql-100.4.7.zip",
-                "shasum": "c10ac242830e02eef83c29c6ebde5536a7ef3c2f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-quote-graph-ql-100.4.8.zip",
+                "shasum": "1fbbfac8dff38d1bd8845f5813d9bea31b62f7e3"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
+                "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-catalog-inventory": "100.4.*",
                 "magento/module-checkout": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-customer-graph-ql": "100.4.*",
                 "magento/module-directory": "100.4.*",
+                "magento/module-downloadable": "100.4.*",
                 "magento/module-eav-graph-ql": "100.4.*",
                 "magento/module-gift-message": "100.4.*",
+                "magento/module-gift-message-graph-ql": "100.4.*",
                 "magento/module-graph-ql": "100.4.*",
+                "magento/module-payment": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-sales-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-inventory-graph-ql": "100.4.*",
@@ -15615,18 +15545,18 @@
         },
         {
             "name": "magento/module-re-captcha-admin-ui",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-admin-ui-1.1.4.zip",
-                "shasum": "fa11663b4b895bb868616813e7673ff2817a7c22"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-admin-ui-1.1.5.zip",
+                "shasum": "401cb0b7b93c2db1ee0b08aab5ca9f22c0eace45"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-config": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15644,11 +15574,11 @@
         },
         {
             "name": "magento/module-re-captcha-checkout",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-checkout-1.1.4.zip",
-                "shasum": "7270891418876a4450728debc6bc9731bfaf1ed1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-checkout-1.1.5.zip",
+                "shasum": "f22156e3549429d80de83c78284964d64612d5ea"
             },
             "require": {
                 "magento/framework": "*",
@@ -15659,7 +15589,7 @@
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
                 "magento/module-re-captcha-webapi-ui": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15677,11 +15607,11 @@
         },
         {
             "name": "magento/module-re-captcha-checkout-sales-rule",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-checkout-sales-rule-1.1.3.zip",
-                "shasum": "1b5a691e16e601dccf996da5d4a4548bef1dcf74"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-checkout-sales-rule-1.1.4.zip",
+                "shasum": "725f6fe5b0b21da0ca5516e6a86e7e9a0e68b272"
             },
             "require": {
                 "magento/framework": "*",
@@ -15693,7 +15623,7 @@
                 "magento/module-re-captcha-webapi-api": "1.0.*",
                 "magento/module-re-captcha-webapi-ui": "1.0.*",
                 "magento/module-sales-rule": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15711,16 +15641,16 @@
         },
         {
             "name": "magento/module-re-captcha-contact",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-contact-1.1.3.zip",
-                "shasum": "4b6b3db0898e8d07b87d4060d7a60bb6a20c2665"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-contact-1.1.4.zip",
+                "shasum": "114b6e527fc87dcf7aa5bfed8a8f25b6295a4450"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15738,11 +15668,11 @@
         },
         {
             "name": "magento/module-re-captcha-customer",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-customer-1.1.5.zip",
-                "shasum": "3f6890c328d344fe2917edb1e279777a025f3e2b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-customer-1.1.6.zip",
+                "shasum": "4d957b739d6ebb0c168a895aa9d4421fc3be51cf"
             },
             "require": {
                 "magento/framework": "*",
@@ -15750,7 +15680,7 @@
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15768,17 +15698,17 @@
         },
         {
             "name": "magento/module-re-captcha-frontend-ui",
-            "version": "1.1.5",
+            "version": "1.1.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-frontend-ui-1.1.5.zip",
-                "shasum": "15df0dcd17c4f0038686f76a7faea1e658f8e0df"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-frontend-ui-1.1.6.zip",
+                "shasum": "7857255adeeedd4ae2fb8f2e9238ed3ad86ea76c"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15796,16 +15726,16 @@
         },
         {
             "name": "magento/module-re-captcha-migration",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-migration-1.1.4.zip",
-                "shasum": "9d9411e86708eef5c6dd36daa0d03a9d074a922f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-migration-1.1.5.zip",
+                "shasum": "66a304157d46027564da53773decbb3158482ddc"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-config": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15823,18 +15753,18 @@
         },
         {
             "name": "magento/module-re-captcha-newsletter",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-newsletter-1.1.4.zip",
-                "shasum": "592e133dda3ad994ceefafd6a26dca7b0d5f2a4b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-newsletter-1.1.5.zip",
+                "shasum": "63be609a137712d54989f1214fc5364e164f271f"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15852,11 +15782,11 @@
         },
         {
             "name": "magento/module-re-captcha-paypal",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-paypal-1.1.4.zip",
-                "shasum": "9c742cee12c6ddf84c67f814edf4460036bf8cb0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-paypal-1.1.5.zip",
+                "shasum": "a2833051b5604f24428372611a0ede31b1789c27"
             },
             "require": {
                 "magento/framework": "*",
@@ -15867,7 +15797,7 @@
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15884,19 +15814,49 @@
             "description": "Google reCaptcha integration for Magento2 PayPal PayflowPro payment form"
         },
         {
-            "name": "magento/module-re-captcha-review",
-            "version": "1.1.4",
+            "name": "magento/module-re-captcha-resend-confirmation-email",
+            "version": "1.1.0",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-review-1.1.4.zip",
-                "shasum": "3b74c96088a2ca6ee8b4d76b120623af7f2d1430"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-resend-confirmation-email-1.1.0.zip",
+                "shasum": "1570a3810fb04a8f03f41f5aaad3c8255f8a4578"
+            },
+            "require": {
+                "magento/framework": "*",
+                "magento/module-customer-graph-ql": "*",
+                "magento/module-re-captcha-ui": "1.1.*",
+                "magento/module-re-captcha-validation-api": "1.1.*",
+                "magento/module-re-captcha-webapi-api": "1.0.*",
+                "php": "~8.2.0||~8.3.0||~8.4.0"
+            },
+            "type": "magento2-module",
+            "autoload": {
+                "files": [
+                    "registration.php"
+                ],
+                "psr-4": {
+                    "Magento\\ReCaptchaResendConfirmationEmail\\": ""
+                }
+            },
+            "license": [
+                "OSL-3.0"
+            ],
+            "description": "Google reCAPTCHA integration for Magento2"
+        },
+        {
+            "name": "magento/module-re-captcha-review",
+            "version": "1.1.5",
+            "dist": {
+                "type": "zip",
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-review-1.1.5.zip",
+                "shasum": "5d049389fd416ff6c609c2521ca70c40eddd5ab2"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15914,18 +15874,18 @@
         },
         {
             "name": "magento/module-re-captcha-send-friend",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-send-friend-1.1.4.zip",
-                "shasum": "7fda411b83f6c2cd462fd5582f8ac2cfff990ede"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-send-friend-1.1.5.zip",
+                "shasum": "fcda4f8637d01692b9d2f8c8fce6f9244fe21e11"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -15943,17 +15903,17 @@
         },
         {
             "name": "magento/module-re-captcha-store-pickup",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-store-pickup-1.0.3.zip",
-                "shasum": "d79c01213319aa15353c76e8a130c0d92dc64165"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-store-pickup-1.0.4.zip",
+                "shasum": "f539245c6a3ff44cea8fcc38cfd15544c8f6e0e8"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-checkout": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-inventory-in-store-pickup-frontend": "*"
@@ -15974,16 +15934,16 @@
         },
         {
             "name": "magento/module-re-captcha-ui",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-ui-1.1.4.zip",
-                "shasum": "19ab942ac92fe62247c90074ffda02cbda82c4cc"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-ui-1.1.5.zip",
+                "shasum": "9f099f1ac9e2499e0f31e15681cd40c95a874d4f"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16007,17 +15967,17 @@
         },
         {
             "name": "magento/module-re-captcha-user",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-user-1.1.4.zip",
-                "shasum": "a605c09fb5c53047d863d03051e906152e2d53ad"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-user-1.1.5.zip",
+                "shasum": "393721440524d26129e3a009fbde193b908ecd50"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16035,17 +15995,17 @@
         },
         {
             "name": "magento/module-re-captcha-validation",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-validation-1.1.3.zip",
-                "shasum": "767ad36205a984e272a14157432af28602b4070d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-validation-1.1.4.zip",
+                "shasum": "fa1716369998e019ef5b225ff36b0b348458b75b"
             },
             "require": {
-                "google/recaptcha": "^1.2",
                 "magento/framework": "*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0",
+                "phpfui/recaptcha": "^2.0.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16063,15 +16023,15 @@
         },
         {
             "name": "magento/module-re-captcha-validation-api",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-validation-api-1.1.3.zip",
-                "shasum": "b772156c0d6d7d154e95f6fe2e63028efc1faafa"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-validation-api-1.1.4.zip",
+                "shasum": "70e99960073f5f1420cb535434547dc8f05d3f03"
             },
             "require": {
                 "magento/framework": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16089,18 +16049,19 @@
         },
         {
             "name": "magento/module-re-captcha-version-2-checkbox",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-2-checkbox-2.0.4.zip",
-                "shasum": "2c7e6bce763fb2887793b391201d0b73f486c059"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-2-checkbox-2.0.5.zip",
+                "shasum": "e8954aa7b37ff96874e2eda7be77f0557c124816"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
+                "magento/module-re-captcha-webapi-graph-ql": "1.0.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "*",
@@ -16122,18 +16083,19 @@
         },
         {
             "name": "magento/module-re-captcha-version-2-invisible",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-2-invisible-2.0.4.zip",
-                "shasum": "0253cacee787c2ed9426ab0572178c8e9fd9a563"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-2-invisible-2.0.5.zip",
+                "shasum": "3a335330d89ff7c51492a7330f73349df0246bf2"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
+                "magento/module-re-captcha-webapi-graph-ql": "1.0.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "*",
@@ -16155,18 +16117,19 @@
         },
         {
             "name": "magento/module-re-captcha-version-3-invisible",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-3-invisible-2.0.4.zip",
-                "shasum": "247aba051ef7cc4d4c757bedd39e9ffeb69fa59a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-version-3-invisible-2.0.5.zip",
+                "shasum": "8de1040bdb63a2d03919761005e23a847b312f71"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-ui": "1.1.*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
+                "magento/module-re-captcha-webapi-graph-ql": "1.0.*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "*",
@@ -16188,16 +16151,16 @@
         },
         {
             "name": "magento/module-re-captcha-webapi-api",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-api-1.0.3.zip",
-                "shasum": "85c721fda826935cc920e19818ae982df441eecd"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-api-1.0.4.zip",
+                "shasum": "0acdc3b2ed7e8f7e031237c376ef4a06544cf33c"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-validation-api": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16215,11 +16178,11 @@
         },
         {
             "name": "magento/module-re-captcha-webapi-graph-ql",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-graph-ql-1.0.3.zip",
-                "shasum": "09173d9dcbd72c80ad420bdd1f6ed57796abcb2e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-graph-ql-1.0.4.zip",
+                "shasum": "3d0d123849832210e7065f075f8929a9671bdfd8"
             },
             "require": {
                 "magento/framework": "*",
@@ -16228,7 +16191,7 @@
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-version-3-invisible": "2.0.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16246,11 +16209,11 @@
         },
         {
             "name": "magento/module-re-captcha-webapi-rest",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-rest-1.0.3.zip",
-                "shasum": "5ceea14c451dc473b472c0c5b16de51e9749c39f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-rest-1.0.4.zip",
+                "shasum": "d742131ce9378afc55dae4407c7eceee36918e9f"
             },
             "require": {
                 "magento/framework": "*",
@@ -16258,7 +16221,7 @@
                 "magento/module-re-captcha-validation-api": "1.1.*",
                 "magento/module-re-captcha-webapi-api": "1.0.*",
                 "magento/module-webapi": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16276,16 +16239,16 @@
         },
         {
             "name": "magento/module-re-captcha-webapi-ui",
-            "version": "1.0.3",
+            "version": "1.0.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-ui-1.0.3.zip",
-                "shasum": "4e660f62b827d62d868eab6319d7ae8ecc987c90"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-webapi-ui-1.0.4.zip",
+                "shasum": "cfdefc2d94d37e43b1520603bdbdf4990d6d0902"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-re-captcha-frontend-ui": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16303,16 +16266,16 @@
         },
         {
             "name": "magento/module-re-captcha-wishlist",
-            "version": "1.1.0-p4",
+            "version": "1.1.4-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-wishlist-1.1.0-p4.zip",
-                "shasum": "a7cf32ca1db4950fde15082d0c694576db5993e7"
+                "url": "https://mirror.mage-os.org/packages/magento/module-re-captcha-wishlist-1.1.4-p1.zip",
+                "shasum": "d5f1bfc54c4e5b285a45648535156d5b8f67354c"
             },
             "require": {
-                "magento/framework": "*",
+                "magento/framework": "103.0.*",
                 "magento/module-re-captcha-ui": "1.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16330,17 +16293,17 @@
         },
         {
             "name": "magento/module-related-product-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-related-product-graph-ql-100.4.4.zip",
-                "shasum": "a1b751cb11bcc432599fce42b034e217ef62ec67"
+                "url": "https://mirror.mage-os.org/packages/magento/module-related-product-graph-ql-100.4.5.zip",
+                "shasum": "079fea3acf41c43ed7606325734eef052dc566bb"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-graph-ql": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -16362,18 +16325,18 @@
         },
         {
             "name": "magento/module-release-notification",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-release-notification-100.4.5.zip",
-                "shasum": "a3cb35192c9d8553a2e8ae994a63400b59b52fe0"
+                "url": "https://mirror.mage-os.org/packages/magento/module-release-notification-100.4.6.zip",
+                "shasum": "519422b82b530564b0a0e277570676d01b992d8a"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -16395,17 +16358,17 @@
         },
         {
             "name": "magento/module-remote-storage",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-remote-storage-100.4.5.zip",
-                "shasum": "b6d34e121980b2e1ba5edbf9525901854c41d36c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-remote-storage-100.4.6.zip",
+                "shasum": "af54603f7c326a72979f8d52fd70a9f3f0d760e4"
             },
             "require": {
-                "league/flysystem": "^2.4",
-                "league/flysystem-aws-s3-v3": "^2.4",
+                "league/flysystem": "^3.0",
+                "league/flysystem-aws-s3-v3": "^3.0",
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-backend": "102.0.*",
@@ -16438,11 +16401,11 @@
         },
         {
             "name": "magento/module-reports",
-            "version": "100.4.7-p4",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-reports-100.4.7-p4.zip",
-                "shasum": "643a90b0f5d656b57f0b8f228dcec8e8a244130a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-reports-100.4.8.zip",
+                "shasum": "eaf6333a074cb686ece0a4ac304ba9d3c93280e6"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16452,7 +16415,6 @@
                 "magento/module-cms": "104.0.*",
                 "magento/module-config": "101.2.*",
                 "magento/module-customer": "103.0.*",
-                "magento/module-directory": "100.4.*",
                 "magento/module-downloadable": "100.4.*",
                 "magento/module-eav": "102.1.*",
                 "magento/module-quote": "101.2.*",
@@ -16463,7 +16425,7 @@
                 "magento/module-tax": "100.4.*",
                 "magento/module-widget": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16482,15 +16444,15 @@
         },
         {
             "name": "magento/module-require-js",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-require-js-100.4.3.zip",
-                "shasum": "a2e848c8b5e756df20074b3f26063ae202e4679f"
+                "url": "https://mirror.mage-os.org/packages/magento/module-require-js-100.4.4.zip",
+                "shasum": "140066db2206ac95329155079bedd2ac853f8d27"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16509,11 +16471,11 @@
         },
         {
             "name": "magento/module-review",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-review-100.4.7.zip",
-                "shasum": "4b64d0b77e39492cf985e49c000324adea056130"
+                "url": "https://mirror.mage-os.org/packages/magento/module-review-100.4.8.zip",
+                "shasum": "50865353b5c177fef4398bce4baf217926081e2a"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16525,7 +16487,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-cookie": "100.4.*",
@@ -16548,17 +16510,17 @@
         },
         {
             "name": "magento/module-review-analytics",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-review-analytics-100.4.4.zip",
-                "shasum": "4c5401bd530f80109663c63f54c59a9d9e8d0f6b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-review-analytics-100.4.5.zip",
+                "shasum": "505c2a21ade191e02695bbe52bd895d4a54219bc"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-review": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16577,18 +16539,18 @@
         },
         {
             "name": "magento/module-review-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-review-graph-ql-100.4.3.zip",
-                "shasum": "4b5fe84672b83d6b4f567ee9a1314371373b0e83"
+                "url": "https://mirror.mage-os.org/packages/magento/module-review-graph-ql-100.4.4.zip",
+                "shasum": "ffe227ae57149e9ce8fd948b4dcc204a315307e0"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-review": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*",
@@ -16611,16 +16573,16 @@
         },
         {
             "name": "magento/module-robots",
-            "version": "101.1.3",
+            "version": "101.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-robots-101.1.3.zip",
-                "shasum": "f6c08ce3707621cc61db42211f614b1157c9cb86"
+                "url": "https://mirror.mage-os.org/packages/magento/module-robots-101.1.4.zip",
+                "shasum": "bfdb6337ace4bd69d596310e0912106175c318d6"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-theme": "101.1.*"
@@ -16642,18 +16604,18 @@
         },
         {
             "name": "magento/module-rss",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-rss-100.4.5.zip",
-                "shasum": "ea4f95b465118b963195e7271158f8f64c322743"
+                "url": "https://mirror.mage-os.org/packages/magento/module-rss-100.4.6.zip",
+                "shasum": "a472c26781da0c7c039d64bd0fc53a232d83b14d"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16672,11 +16634,11 @@
         },
         {
             "name": "magento/module-rule",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-rule-100.4.6.zip",
-                "shasum": "37d0ca8b9ab6e0058c274a4b411fa39cc7c6f9e1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-rule-100.4.7.zip",
+                "shasum": "1921e9cb660dbfe6d7a9989af0bfca6d6c20474f"
             },
             "require": {
                 "lib-libxml": "*",
@@ -16685,7 +16647,7 @@
                 "magento/module-catalog": "104.0.*",
                 "magento/module-eav": "102.1.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16704,11 +16666,11 @@
         },
         {
             "name": "magento/module-saas-common",
-            "version": "103.3.18",
+            "version": "103.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-saas-common-103.3.18.0.zip",
-                "shasum": "cec2e2b6929efd38135e13bbcbcf611709a7a441"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-saas-common-103.4.5.0.zip",
+                "shasum": "3e5f7bb97b258ec6f1b1b063a1d33c48878584bb"
             },
             "require": {
                 "magento/framework": ">=103.0.4",
@@ -16741,11 +16703,11 @@
         },
         {
             "name": "magento/module-sales",
-            "version": "103.0.7-p4",
+            "version": "103.0.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-103.0.7-p4.zip",
-                "shasum": "86f45cab3bdb7c50d571309024143d99dac8898c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-103.0.8.zip",
+                "shasum": "d7b89cc8c9c596cce9b9d0659a4905d867f28c6d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16774,7 +16736,7 @@
                 "magento/module-ui": "101.2.*",
                 "magento/module-widget": "101.2.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-sales-sample-data": "Sample Data version: 100.4.*"
@@ -16796,17 +16758,17 @@
         },
         {
             "name": "magento/module-sales-analytics",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-analytics-100.4.4.zip",
-                "shasum": "1b30821fd79a70e18d14df94a4ce67e5c4698780"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-analytics-100.4.5.zip",
+                "shasum": "f3359a5f6349d1ee49270db3988ecb7d30176443"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-sales": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16825,11 +16787,11 @@
         },
         {
             "name": "magento/module-sales-data-exporter",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-sales-data-exporter-2.10.1.0.zip",
-                "shasum": "aa0a68c399daa738ac3d26d82c59fbd8ad9c46e5"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-sales-data-exporter-2.11.1.0.zip",
+                "shasum": "e522090c541b20bfbe631681540246a803684df0"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
@@ -16855,11 +16817,11 @@
         },
         {
             "name": "magento/module-sales-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-graph-ql-100.4.7.zip",
-                "shasum": "1904e20f587c2594f31587527e8fa16886a6f8d9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-graph-ql-100.4.8.zip",
+                "shasum": "ca917f73316b156d3f3fabaf3dc1ab3619e44b63"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16867,11 +16829,12 @@
                 "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-quote": "101.2.*",
+                "magento/module-quote-graph-ql": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16890,11 +16853,11 @@
         },
         {
             "name": "magento/module-sales-inventory",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-inventory-100.4.4.zip",
-                "shasum": "18b24ab787a731f45eae3615827799c2ddc0dc95"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-inventory-100.4.5.zip",
+                "shasum": "d2d223e80c18bb7739e827bd14c7a25ac8b73253"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16902,7 +16865,7 @@
                 "magento/module-catalog-inventory": "100.4.*",
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -16921,11 +16884,11 @@
         },
         {
             "name": "magento/module-sales-rule",
-            "version": "101.2.7-p4",
+            "version": "101.2.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-rule-101.2.7-p4.zip",
-                "shasum": "a8934b0eb3c595fd7aefcd1181d7d87d528621ad"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-rule-101.2.8-p1.zip",
+                "shasum": "74b87f97d5bdebab776cf45f798fb18f41ad395d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -16941,6 +16904,7 @@
                 "magento/module-customer": "103.0.*",
                 "magento/module-directory": "100.4.*",
                 "magento/module-eav": "102.1.*",
+                "magento/module-multishipping": "100.4.*",
                 "magento/module-payment": "100.4.*",
                 "magento/module-quote": "101.2.*",
                 "magento/module-reports": "100.4.*",
@@ -16948,9 +16912,10 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
+                "magento/module-tax": "100.4.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-widget": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-sales-rule-sample-data": "Sample Data version: 100.4.*"
@@ -16972,16 +16937,16 @@
         },
         {
             "name": "magento/module-sales-rule-graph-ql",
-            "version": "100.4.0",
+            "version": "100.4.1-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-rule-graph-ql-100.4.0.zip",
-                "shasum": "f218ae6333f2f8a7c7ad622f6c1fb5fdcd007fe4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-rule-graph-ql-100.4.1-p1.zip",
+                "shasum": "b758e2631addc5c35b1e8d2c0cf43f801957262b"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-sales-rule": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17000,15 +16965,15 @@
         },
         {
             "name": "magento/module-sales-sequence",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sales-sequence-100.4.4.zip",
-                "shasum": "eded77fb80ec78db009b690bc79ae18305599af9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sales-sequence-100.4.5.zip",
+                "shasum": "29ea25c0532e82a7bf87b45ad0d56e420c8986e5"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17027,15 +16992,15 @@
         },
         {
             "name": "magento/module-sample-data",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sample-data-100.4.5.zip",
-                "shasum": "be8a5678cc13a844b68e5cca412404f60de71924"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sample-data-100.4.6.zip",
+                "shasum": "e754785c779e50febf048f37114beaff0a8aa2a6"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/sample-data-media": "Sample Data version: 100.4.*"
@@ -17058,11 +17023,11 @@
         },
         {
             "name": "magento/module-search",
-            "version": "101.1.7-p3",
+            "version": "101.1.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-search-101.1.7-p3.zip",
-                "shasum": "83e6013936cb3850de245310f9d63d19e742cfd8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-search-101.1.8.zip",
+                "shasum": "c1e14fc5d09c3f0dce62179f64948a38ddcdff19"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17071,7 +17036,7 @@
                 "magento/module-reports": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17090,11 +17055,11 @@
         },
         {
             "name": "magento/module-security",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-security-100.4.7.zip",
-                "shasum": "2ff9c25d747ecb98f6292fd0e662bba233c44dd6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-security-100.4.8.zip",
+                "shasum": "a555d2b8f91d3151b1a8828086d86f38b425fa97"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17102,7 +17067,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-customer": "103.0.*"
@@ -17124,17 +17089,17 @@
         },
         {
             "name": "magento/module-securitytxt",
-            "version": "1.1.3",
+            "version": "1.1.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-securitytxt-1.1.3.zip",
-                "shasum": "a69783f75e8a1b0b90f7733512ed2cf5d6bff314"
+                "url": "https://mirror.mage-os.org/packages/magento/module-securitytxt-1.1.4.zip",
+                "shasum": "22f54de0e44c0cc5fdf1e6d2780d2da9f84f7f8f"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-config": "*",
                 "magento/module-store": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17159,11 +17124,11 @@
         },
         {
             "name": "magento/module-send-friend",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-send-friend-100.4.5.zip",
-                "shasum": "b689042a78cb29a956497afba8e8839451e80b15"
+                "url": "https://mirror.mage-os.org/packages/magento/module-send-friend-100.4.6.zip",
+                "shasum": "6f4e47de64df2d38c5d0f8fbb42c397153e15147"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17173,7 +17138,7 @@
                 "magento/module-customer": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17192,18 +17157,18 @@
         },
         {
             "name": "magento/module-send-friend-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-send-friend-graph-ql-100.4.3.zip",
-                "shasum": "758216046f7d5782fc009f41a7cf735552daf9d8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-send-friend-graph-ql-100.4.4.zip",
+                "shasum": "f5ec53d3d520f827c6068ecc829176d2b2a90329"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-send-friend": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17222,17 +17187,17 @@
         },
         {
             "name": "magento/module-service-proxy",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-service-proxy-2.10.1.0.zip",
-                "shasum": "6deeb10d01d9c12b7b0a67417aef0ac535a2668a"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-service-proxy-2.11.1.0.zip",
+                "shasum": "165332b5a08feebf2d0db71baf831b276728f78e"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
                 "magento/module-backend": ">=102.0.4 <103.0.0",
                 "magento/module-page-cache": ">=100.4.4 <101.0.0",
-                "magento/module-payment-services-paypal": "2.10.1",
+                "magento/module-payment-services-paypal": "2.11.1",
                 "magento/module-store": ">=101.1.4 <102.0.0",
                 "php": "~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
@@ -17253,11 +17218,11 @@
         },
         {
             "name": "magento/module-services-id",
-            "version": "3.2.7",
+            "version": "3.3.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-3.2.7.0.zip",
-                "shasum": "621545540765525f79e9e3cb9859b09ab2e5bf5b"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-3.3.1.0.zip",
+                "shasum": "761978e919fabe3fbfc0122486d8afa7806a5ff7"
             },
             "require": {
                 "magento/framework": ">=102.0.0 <104.0.0",
@@ -17282,17 +17247,17 @@
         },
         {
             "name": "magento/module-services-id-graph-ql-server",
-            "version": "1.1.6",
+            "version": "1.1.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-graph-ql-server-1.1.6.0.zip",
-                "shasum": "4ff4df35fd997afeac043ff678ff935cdbf39a72"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-graph-ql-server-1.1.8.0.zip",
+                "shasum": "3c36536fb1ca7331ec22c1d68b4a4a86982acf64"
             },
             "require": {
                 "magento/framework": ">=102.0.0 <104.0.0",
                 "magento/module-admin-graph-ql-server": "^1.0.4",
                 "magento/module-backend": ">=101.0.0 <103.0.0",
-                "magento/module-services-id": "^3.2.7",
+                "magento/module-services-id": "^3.3.1",
                 "magento/services-connector": "^1.3.6",
                 "php": "~7.2.0||~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
@@ -17313,19 +17278,19 @@
         },
         {
             "name": "magento/module-services-id-layout",
-            "version": "1.1.4",
+            "version": "1.1.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-layout-1.1.4.0.zip",
-                "shasum": "34b55c59193b3897987d29997868c26dcf47229e"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-services-id-layout-1.1.6.0.zip",
+                "shasum": "1a5d32cb97b3c26ea62fc18392ca96b9f458045f"
             },
             "require": {
                 "magento/framework": ">=102.0.0 <104.0.0",
                 "magento/module-backend": ">=101.0.0 <103.0.0",
                 "magento/module-config": ">=101.1.0 <101.3.0",
                 "magento/module-graph-ql-server": "^1.0.3",
-                "magento/module-services-id": "^3.2.7",
-                "magento/module-services-id-graph-ql-server": "^1.1.6",
+                "magento/module-services-id": "^3.3.1",
+                "magento/module-services-id-graph-ql-server": "^1.1.8",
                 "magento/module-store": ">=101.0.0 <101.2.0",
                 "php": "~7.2.0||~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0"
             },
@@ -17346,11 +17311,11 @@
         },
         {
             "name": "magento/module-shipping",
-            "version": "100.4.7-p2",
+            "version": "100.4.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-shipping-100.4.7-p2.zip",
-                "shasum": "a08d44cc99d648b53ed6242f8180083b3c63b1df"
+                "url": "https://mirror.mage-os.org/packages/magento/module-shipping-100.4.8-p1.zip",
+                "shasum": "de64e120909157cb7da6691f39a52f19995becdf"
             },
             "require": {
                 "ext-gd": "*",
@@ -17368,7 +17333,7 @@
                 "magento/module-tax": "100.4.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*",
@@ -17392,11 +17357,11 @@
         },
         {
             "name": "magento/module-sitemap",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-sitemap-100.4.6.zip",
-                "shasum": "c099383086f13f16e3339513174dc4ae1cbca264"
+                "url": "https://mirror.mage-os.org/packages/magento/module-sitemap-100.4.7.zip",
+                "shasum": "f67e65562f59cd6f91e85b4197d94d420a116f31"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17409,7 +17374,7 @@
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-robots": "101.1.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -17431,11 +17396,11 @@
         },
         {
             "name": "magento/module-store",
-            "version": "101.1.7",
+            "version": "101.1.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-store-101.1.7.zip",
-                "shasum": "ec73a2862817c5c23f8c0ac4e495d68b9bdd613d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-store-101.1.8.zip",
+                "shasum": "fc1170433ba842fb1a672cf034f067cd6720cd21"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17447,7 +17412,7 @@
                 "magento/module-directory": "100.4.*",
                 "magento/module-media-storage": "100.4.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-deploy": "100.4.*"
@@ -17469,11 +17434,11 @@
         },
         {
             "name": "magento/module-store-data-exporter",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-module-store-data-exporter-2.10.1.0.zip",
-                "shasum": "0788525e6bce47d81de38af5084768eabad7490a"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-module-store-data-exporter-2.11.1.0.zip",
+                "shasum": "dc60f2c2d711de8d807f4fd8b014ac66df9e3fdf"
             },
             "require": {
                 "magento/framework": ">=103.0.4 <104.0.0",
@@ -17499,11 +17464,11 @@
         },
         {
             "name": "magento/module-store-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-store-graph-ql-100.4.5.zip",
-                "shasum": "0c0d04a644ef27be1bad52486e89d4fab20738e3"
+                "url": "https://mirror.mage-os.org/packages/magento/module-store-graph-ql-100.4.6.zip",
+                "shasum": "7ab7ff95a46a2f0cb461f9f63ad7bc0201abce57"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17511,7 +17476,7 @@
                 "magento/module-graph-ql-cache": "100.4.*",
                 "magento/module-graph-ql-resolver-cache": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17530,15 +17495,15 @@
         },
         {
             "name": "magento/module-swagger",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-100.4.6.zip",
-                "shasum": "297f3abca5a3861876c3fabf177141cb71d1532a"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-100.4.7.zip",
+                "shasum": "c8adcc32e9c635041d4d428ef9c28de4d38e3a62"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17557,16 +17522,16 @@
         },
         {
             "name": "magento/module-swagger-webapi",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-webapi-100.4.3.zip",
-                "shasum": "1cdabdc648172f77890e97848cf10833ef5c4103"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-webapi-100.4.4.zip",
+                "shasum": "61b374ee5559785f90b0b3481cab8e9f1a2da0c8"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-swagger": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17585,16 +17550,16 @@
         },
         {
             "name": "magento/module-swagger-webapi-async",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-webapi-async-100.4.3.zip",
-                "shasum": "e3138936ae9cac8d289b99b0e6e113625a9cd895"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swagger-webapi-async-100.4.4.zip",
+                "shasum": "31ecc4373ad3dd1f00620d729bdac643cefec237"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-swagger": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -17616,11 +17581,11 @@
         },
         {
             "name": "magento/module-swatches",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-100.4.7.zip",
-                "shasum": "badc8cc397cd67054324b4b56e58279c923c5217"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-100.4.8.zip",
+                "shasum": "1ddd4961f2651cf985e81608a99e4e26cb91b06f"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17634,7 +17599,7 @@
                 "magento/module-page-cache": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-layered-navigation": "100.4.*",
@@ -17657,18 +17622,18 @@
         },
         {
             "name": "magento/module-swatches-graph-ql",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-graph-ql-100.4.5.zip",
-                "shasum": "5730498049aaf658322a085e6c8766d6c67e483d"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-graph-ql-100.4.6.zip",
+                "shasum": "cc98ec0c696ae5ab7a97d7e10ca3f0c68afbf5da"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-catalog-graph-ql": "100.4.*",
                 "magento/module-swatches": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-configurable-product-graph-ql": "100.4.*"
@@ -17690,16 +17655,16 @@
         },
         {
             "name": "magento/module-swatches-layered-navigation",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-layered-navigation-100.4.3.zip",
-                "shasum": "4c632c03462967c34a46714aa21a4ca26a28a1fd"
+                "url": "https://mirror.mage-os.org/packages/magento/module-swatches-layered-navigation-100.4.4.zip",
+                "shasum": "cd6973cccd7e3c2d369d840096153f3df7171773"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/magento-composer-installer": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17718,11 +17683,11 @@
         },
         {
             "name": "magento/module-tax",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-tax-100.4.7.zip",
-                "shasum": "c3d8c2eb31271e7a7e6dded1cf7a276fbf55685b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-tax-100.4.8.zip",
+                "shasum": "116fc3bf01e2f299d777a1943ce4da851b919ba7"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17740,7 +17705,7 @@
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-tax-sample-data": "Sample Data version: 100.4.*"
@@ -17762,15 +17727,15 @@
         },
         {
             "name": "magento/module-tax-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-tax-graph-ql-100.4.3.zip",
-                "shasum": "694aaa45d86472d8a0164060632a42c3245d1fda"
+                "url": "https://mirror.mage-os.org/packages/magento/module-tax-graph-ql-100.4.4.zip",
+                "shasum": "86afd6e4c76836259f1c9ac8120529be51399dfd"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*",
@@ -17793,11 +17758,11 @@
         },
         {
             "name": "magento/module-tax-import-export",
-            "version": "100.4.6-p2",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-tax-import-export-100.4.6-p2.zip",
-                "shasum": "e5c7a4b8295d14380615c90dd43f1c77521a84c8"
+                "url": "https://mirror.mage-os.org/packages/magento/module-tax-import-export-100.4.7.zip",
+                "shasum": "48ff63a2a6b6390cd5acf7ff707f62d51a0f4645"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17806,7 +17771,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -17825,17 +17790,18 @@
         },
         {
             "name": "magento/module-theme",
-            "version": "101.1.7",
+            "version": "101.1.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-theme-101.1.7.zip",
-                "shasum": "fd1bafa546dd465dcd91e817c270ff4755a8de17"
+                "url": "https://mirror.mage-os.org/packages/magento/module-theme-101.1.8-p1.zip",
+                "shasum": "953812419d2dfa0fa8166deaeb403cc9072b1710"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-cms": "104.0.*",
                 "magento/module-config": "101.2.*",
+                "magento/module-csp": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-eav": "102.1.*",
                 "magento/module-media-storage": "100.4.*",
@@ -17843,7 +17809,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-widget": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-deploy": "100.4.*",
@@ -17867,15 +17833,15 @@
         },
         {
             "name": "magento/module-theme-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-theme-graph-ql-100.4.4.zip",
-                "shasum": "fa71cac44025af30f77696073fd278dd29443e66"
+                "url": "https://mirror.mage-os.org/packages/magento/module-theme-graph-ql-100.4.5.zip",
+                "shasum": "f06441fac9e47731e8bdfd5fc99c90faff0862fb"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-store-graph-ql": "100.4.*"
@@ -17897,11 +17863,11 @@
         },
         {
             "name": "magento/module-translation",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-translation-100.4.7.zip",
-                "shasum": "3a11fa3af713e52613349f187030919c5579489c"
+                "url": "https://mirror.mage-os.org/packages/magento/module-translation-100.4.8.zip",
+                "shasum": "3d315256d522bea7ec80c22655be064132e9c0d2"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17910,7 +17876,7 @@
                 "magento/module-developer": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-deploy": "100.4.*"
@@ -17932,16 +17898,18 @@
         },
         {
             "name": "magento/module-two-factor-auth",
-            "version": "1.1.6-p3",
+            "version": "1.1.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-two-factor-auth-1.1.6-p3.zip",
-                "shasum": "47f83470629b83fc6e70649622ca8fa8bdf6dabc"
+                "url": "https://mirror.mage-os.org/packages/magento/module-two-factor-auth-1.1.7.zip",
+                "shasum": "0c95b67d1cb08802bf4aedc8e9e07a59e14bff2d"
             },
             "require": {
                 "2tvenom/cborencode": "^1.0",
                 "christian-riesen/base32": "^1.3",
-                "endroid/qr-code": "^4.3.5",
+                "duosecurity/duo_api_php": "^1.1",
+                "duosecurity/duo_universal_php": "^1.0",
+                "endroid/qr-code": "^6.0.3",
                 "magento/framework": "*",
                 "magento/magento-composer-installer": "*",
                 "magento/module-authorization": "*",
@@ -17951,7 +17919,7 @@
                 "magento/module-store": "*",
                 "magento/module-ui": "*",
                 "magento/module-user": "*",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "spomky-labs/otphp": "^11.2"
             },
             "type": "magento2-module",
@@ -17970,11 +17938,11 @@
         },
         {
             "name": "magento/module-ui",
-            "version": "101.2.7-p4",
+            "version": "101.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-ui-101.2.7-p4.zip",
-                "shasum": "9699b3e0d0069eb743b7dd3d828657f648e29e74"
+                "url": "https://mirror.mage-os.org/packages/magento/module-ui-101.2.8.zip",
+                "shasum": "9ce7e167c1652a2ae8930fb25f562690c7ce2439"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -17983,7 +17951,7 @@
                 "magento/module-eav": "102.1.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-user": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -18005,11 +17973,11 @@
         },
         {
             "name": "magento/module-ups",
-            "version": "100.4.7-p1",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-ups-100.4.7-p1.zip",
-                "shasum": "8966a9cb194f8d1d327153b5f31dd6c9f26a1400"
+                "url": "https://mirror.mage-os.org/packages/magento/module-ups-100.4.8.zip",
+                "shasum": "86f2ce974888273f92f2aaa10cb6c6405a751dcf"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18020,7 +17988,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-config": "101.2.*"
@@ -18042,11 +18010,11 @@
         },
         {
             "name": "magento/module-url-rewrite",
-            "version": "102.0.6",
+            "version": "102.0.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-url-rewrite-102.0.6.zip",
-                "shasum": "bccf90a267237862ae5bc85d3991d7e6e70cc91e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-url-rewrite-102.0.7.zip",
+                "shasum": "19eff763536baa6714081aa7bbbe15d2ba1aa385"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18057,7 +18025,7 @@
                 "magento/module-cms-url-rewrite": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18076,16 +18044,16 @@
         },
         {
             "name": "magento/module-url-rewrite-graph-ql",
-            "version": "100.4.6",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-url-rewrite-graph-ql-100.4.6.zip",
-                "shasum": "46f903a7db7b42c530ce8f66d6e73eb4eb048789"
+                "url": "https://mirror.mage-os.org/packages/magento/module-url-rewrite-graph-ql-100.4.7.zip",
+                "shasum": "40aac68fb2dfa9c92f49824e55c20110a6d58a10"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-url-rewrite": "102.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-graph-ql": "100.4.*"
@@ -18107,11 +18075,11 @@
         },
         {
             "name": "magento/module-user",
-            "version": "101.2.7",
+            "version": "101.2.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-user-101.2.7.zip",
-                "shasum": "ad450446a25edd605f022dd563641a397cf3d8c1"
+                "url": "https://mirror.mage-os.org/packages/magento/module-user-101.2.8-p1.zip",
+                "shasum": "d35480fd3b769724c33934b93a11b2867f3d0aec"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18122,7 +18090,7 @@
                 "magento/module-security": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18141,11 +18109,11 @@
         },
         {
             "name": "magento/module-usps",
-            "version": "100.4.6-p3",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-usps-100.4.6-p3.zip",
-                "shasum": "e63a6513555e101f6da5d94b941c602ef5f771f4"
+                "url": "https://mirror.mage-os.org/packages/magento/module-usps-100.4.7.zip",
+                "shasum": "81d8b83fb1ee3ebdcc1930c558a8c4e4518ddb22"
             },
             "require": {
                 "lib-libxml": "*",
@@ -18158,7 +18126,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-shipping": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18177,11 +18145,11 @@
         },
         {
             "name": "magento/module-variable",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-variable-100.4.5.zip",
-                "shasum": "7e2c5ef651b2b8cba2b3a03ed77717412ea5b587"
+                "url": "https://mirror.mage-os.org/packages/magento/module-variable-100.4.6.zip",
+                "shasum": "5eb0e3e48cc7899c96c6c47d5ddad741070c8132"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18189,7 +18157,7 @@
                 "magento/module-config": "101.2.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18208,11 +18176,11 @@
         },
         {
             "name": "magento/module-vault",
-            "version": "101.2.7",
+            "version": "101.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-vault-101.2.7.zip",
-                "shasum": "4d000e022d05c71f35cee555abba016c05e92406"
+                "url": "https://mirror.mage-os.org/packages/magento/module-vault-101.2.8.zip",
+                "shasum": "4c02322134678f40c65016269fa3bfb65022f289"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18223,7 +18191,7 @@
                 "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18241,17 +18209,17 @@
         },
         {
             "name": "magento/module-vault-graph-ql",
-            "version": "100.4.3",
+            "version": "100.4.4",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-vault-graph-ql-100.4.3.zip",
-                "shasum": "e7a355104a1d59cfa18b0f6061445b57a6656358"
+                "url": "https://mirror.mage-os.org/packages/magento/module-vault-graph-ql-100.4.4.zip",
+                "shasum": "aeac78ac93f9d99f41cef91a7534b292b9386499"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-graph-ql": "100.4.*",
                 "magento/module-vault": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18270,15 +18238,15 @@
         },
         {
             "name": "magento/module-version",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-version-100.4.4.zip",
-                "shasum": "f2673eff1f55200a2570707c572290d3e7ff55ca"
+                "url": "https://mirror.mage-os.org/packages/magento/module-version-100.4.5.zip",
+                "shasum": "91ef5a34b23ab7bc286b641d565d5fa19cb32b36"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18297,11 +18265,11 @@
         },
         {
             "name": "magento/module-webapi",
-            "version": "100.4.6-p1",
+            "version": "100.4.7",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-100.4.6-p1.zip",
-                "shasum": "ec185d06c54bffea97b97201cec73dea3dc85513"
+                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-100.4.7.zip",
+                "shasum": "fbc9ab1a3ca2275e2f3d941c375806f92b5cdb5e"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18309,7 +18277,7 @@
                 "magento/module-backend": "102.0.*",
                 "magento/module-integration": "100.4.*",
                 "magento/module-store": "101.1.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-customer": "103.0.*",
@@ -18332,18 +18300,18 @@
         },
         {
             "name": "magento/module-webapi-async",
-            "version": "100.4.5-p4",
+            "version": "100.4.6-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-async-100.4.5-p4.zip",
-                "shasum": "582e5ecbc35325a58e0efa3cf90925c34823a0b6"
+                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-async-100.4.6-p1.zip",
+                "shasum": "936b38c2c8457d21493f48729b99d535fe116877"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-asynchronous-operations": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-webapi": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-customer": "103.0.*",
@@ -18366,16 +18334,16 @@
         },
         {
             "name": "magento/module-webapi-security",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-security-100.4.4.zip",
-                "shasum": "ab3b6c21290e074047936a989152624f1694f21b"
+                "url": "https://mirror.mage-os.org/packages/magento/module-webapi-security-100.4.5.zip",
+                "shasum": "a17a5002dc001983eae0b87b9238bdba1754261e"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-webapi": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18394,17 +18362,18 @@
         },
         {
             "name": "magento/module-weee",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-weee-100.4.7.zip",
-                "shasum": "3d4c701b35208e54fc9471ae074c47e702dffeb9"
+                "url": "https://mirror.mage-os.org/packages/magento/module-weee-100.4.8.zip",
+                "shasum": "f212607de2180bb98ced128722103f126b37441b"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-backend": "102.0.*",
                 "magento/module-catalog": "104.0.*",
                 "magento/module-checkout": "100.4.*",
+                "magento/module-configurable-product": "100.4.*",
                 "magento/module-customer": "103.0.*",
                 "magento/module-directory": "100.4.*",
                 "magento/module-eav": "102.1.*",
@@ -18414,7 +18383,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-bundle": "101.0.*"
@@ -18436,18 +18405,19 @@
         },
         {
             "name": "magento/module-weee-graph-ql",
-            "version": "100.4.4",
+            "version": "100.4.5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-weee-graph-ql-100.4.4.zip",
-                "shasum": "6fdaefbdf96118f2a4886560d792523bf4eed517"
+                "url": "https://mirror.mage-os.org/packages/magento/module-weee-graph-ql-100.4.5.zip",
+                "shasum": "6c3287aa8dc5781eac989a5a2cad9ba11fbdf396"
             },
             "require": {
                 "magento/framework": "103.0.*",
+                "magento/module-sales": "103.0.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-tax": "100.4.*",
                 "magento/module-weee": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-catalog-graph-ql": "100.4.*"
@@ -18469,11 +18439,11 @@
         },
         {
             "name": "magento/module-widget",
-            "version": "101.2.7",
+            "version": "101.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-widget-101.2.7.zip",
-                "shasum": "8c240f95b1677eba70640553809e152986556d16"
+                "url": "https://mirror.mage-os.org/packages/magento/module-widget-101.2.8.zip",
+                "shasum": "6a66a6d236e30c062618dce0d80d19df294b345d"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18485,7 +18455,7 @@
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
                 "magento/module-variable": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-widget-sample-data": "Sample Data version: 100.4.*"
@@ -18507,11 +18477,11 @@
         },
         {
             "name": "magento/module-wishlist",
-            "version": "101.2.7-p3",
+            "version": "101.2.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-101.2.7-p3.zip",
-                "shasum": "b78bbb428ba4f428be278c18d8f68115e43468ff"
+                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-101.2.8.zip",
+                "shasum": "e90bf66ba2a3d7c593bb6d3daa40ba14c804cea1"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18526,7 +18496,7 @@
                 "magento/module-store": "101.1.*",
                 "magento/module-theme": "101.1.*",
                 "magento/module-ui": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "suggest": {
                 "magento/module-bundle": "101.0.*",
@@ -18553,17 +18523,17 @@
         },
         {
             "name": "magento/module-wishlist-analytics",
-            "version": "100.4.5",
+            "version": "100.4.6",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-analytics-100.4.5.zip",
-                "shasum": "2ef22b23b47524aa8def7cc9ae0a3ea2f3e354dc"
+                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-analytics-100.4.6.zip",
+                "shasum": "80a8947f95ef8857336df65602309b983317c636"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/module-analytics": "100.4.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18582,11 +18552,11 @@
         },
         {
             "name": "magento/module-wishlist-graph-ql",
-            "version": "100.4.7",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-graph-ql-100.4.7.zip",
-                "shasum": "85d0628a67e0a3e8bd2473c29d8060cdf21dea1e"
+                "url": "https://mirror.mage-os.org/packages/magento/module-wishlist-graph-ql-100.4.8.zip",
+                "shasum": "9afff3da8caeefcfb8ff3a6968e1dba1b6a86404"
             },
             "require": {
                 "magento/framework": "103.0.*",
@@ -18596,7 +18566,7 @@
                 "magento/module-quote-graph-ql": "100.4.*",
                 "magento/module-store": "101.1.*",
                 "magento/module-wishlist": "101.2.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-module",
             "autoload": {
@@ -18615,40 +18585,41 @@
         },
         {
             "name": "magento/page-builder",
-            "version": "1.7.4-p4",
+            "version": "1.7.5-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/page-builder-1.7.4-p4.zip",
-                "shasum": "13ab02d800e556ccb06b60017ea1d7ac03869301"
+                "url": "https://mirror.mage-os.org/packages/magento/page-builder-1.7.5-p1.zip",
+                "shasum": "42b54657d77a7c54a23c430b96d2d17dc3b3d2fa"
             },
             "require": {
-                "magento/module-aws-s3-page-builder": "1.0.4",
-                "magento/module-catalog-page-builder-analytics": "1.6.4",
-                "magento/module-cms-page-builder-analytics": "1.6.4",
-                "magento/module-page-builder": "2.2.5-p4",
-                "magento/module-page-builder-admin-analytics": "1.1.4",
-                "magento/module-page-builder-analytics": "1.6.4"
+                "magento/module-aws-s3-page-builder": "1.0.5",
+                "magento/module-catalog-page-builder-analytics": "1.6.5",
+                "magento/module-cms-page-builder-analytics": "1.6.5",
+                "magento/module-page-builder": "2.2.6-p1",
+                "magento/module-page-builder-admin-analytics": "1.1.5",
+                "magento/module-page-builder-analytics": "1.6.5",
+                "magento/module-page-builder-image-attribute": "1.7.5"
             },
             "type": "metapackage",
             "description": "Page Builder metapackage"
         },
         {
             "name": "magento/payment-services",
-            "version": "2.10.1",
+            "version": "2.11.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-payment-services-2.10.1.0.zip",
-                "shasum": "5016fa85a61fe20a2effa513ebaf733fff125516"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-payment-services-2.11.1.0.zip",
+                "shasum": "1ebb18b6bf05411a0e6864d243e60049876d9edb"
             },
             "require": {
-                "magento/module-payment-services-base": "2.10.1",
-                "magento/module-payment-services-dashboard": "2.10.1",
-                "magento/module-payment-services-paypal": "2.10.1",
-                "magento/module-payment-services-paypal-graph-ql": "2.10.1",
-                "magento/module-payment-services-saas-export": "2.10.1",
-                "magento/module-sales-data-exporter": "2.10.1",
-                "magento/module-service-proxy": "2.10.1",
-                "magento/module-store-data-exporter": "2.10.1",
+                "magento/module-payment-services-base": "2.11.1",
+                "magento/module-payment-services-dashboard": "2.11.1",
+                "magento/module-payment-services-paypal": "2.11.1",
+                "magento/module-payment-services-paypal-graph-ql": "2.11.1",
+                "magento/module-payment-services-saas-export": "2.11.1",
+                "magento/module-sales-data-exporter": "2.11.1",
+                "magento/module-service-proxy": "2.11.1",
+                "magento/module-store-data-exporter": "2.11.1",
                 "magento/services-id": "^3.2.0"
             },
             "type": "metapackage",
@@ -18656,26 +18627,29 @@
         },
         {
             "name": "magento/product-community-edition",
-            "version": "2.4.7-p4",
+            "version": "2.4.8-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/product-community-edition-2.4.7-p4.zip",
-                "shasum": "f43a57af776d5908844fa379cfeccf83c7503bed"
+                "url": "https://mirror.mage-os.org/packages/magento/product-community-edition-2.4.8-p1.zip",
+                "shasum": "49acd9c60d8fffddfa2e76f49e7d114bd99eaa07"
             },
             "require": {
-                "adobe-commerce/os-extensions-metapackage": "~1.0",
+                "adobe-commerce/os-extensions-metapackage": "^1.0.1",
                 "colinmollenhour/cache-backend-file": "^1.4",
                 "colinmollenhour/cache-backend-redis": "^1.16",
                 "colinmollenhour/credis": "^1.15",
-                "colinmollenhour/php-redis-session-abstract": "~1.5.3",
+                "colinmollenhour/php-redis-session-abstract": "^2.0",
                 "components/jquery": "1.11.0",
                 "components/jqueryui": "1.10.4",
                 "composer/composer": "^2.0, !=2.2.16",
-                "elasticsearch/elasticsearch": "~7.17.0 || ~8.5.0",
+                "duosecurity/duo_api_php": "^1.1",
+                "duosecurity/duo_universal_php": "^1.0",
+                "elasticsearch/elasticsearch": "^8.15",
                 "ext-bcmath": "*",
                 "ext-ctype": "*",
                 "ext-curl": "*",
                 "ext-dom": "*",
+                "ext-ftp": "*",
                 "ext-gd": "*",
                 "ext-hash": "*",
                 "ext-iconv": "*",
@@ -18690,39 +18664,33 @@
                 "ext-zip": "*",
                 "ezyang/htmlpurifier": "^4.17",
                 "guzzlehttp/guzzle": "^7.5",
-                "laminas/laminas-captcha": "^2.17",
+                "laminas/laminas-captcha": "^2.18",
                 "laminas/laminas-code": "^4.13",
-                "laminas/laminas-db": "^2.19",
-                "laminas/laminas-di": "^3.13",
+                "laminas/laminas-di": "^3.15",
                 "laminas/laminas-escaper": "^2.13",
                 "laminas/laminas-eventmanager": "^3.11",
                 "laminas/laminas-feed": "^2.22",
-                "laminas/laminas-file": "^2.13",
                 "laminas/laminas-filter": "^2.33",
                 "laminas/laminas-http": "^2.15",
                 "laminas/laminas-i18n": "^2.17",
-                "laminas/laminas-mail": "^2.16",
-                "laminas/laminas-mime": "^2.9",
                 "laminas/laminas-modulemanager": "^2.11",
                 "laminas/laminas-mvc": "^3.6",
-                "laminas/laminas-oauth": "^2.6",
                 "laminas/laminas-permissions-acl": "^2.10",
-                "laminas/laminas-server": "^2.16",
                 "laminas/laminas-servicemanager": "^3.16",
                 "laminas/laminas-soap": "^2.10",
                 "laminas/laminas-stdlib": "^3.11",
                 "laminas/laminas-uri": "^2.9",
                 "laminas/laminas-validator": "^2.23",
-                "league/flysystem": "^2.4",
-                "league/flysystem-aws-s3-v3": "^2.4",
+                "league/flysystem": "^3.0",
+                "league/flysystem-aws-s3-v3": "^3.0",
                 "lib-libxml": "*",
-                "magento/composer": "^1.10.0-beta1",
+                "magento/composer": "^1.10.1-beta1",
                 "magento/composer-dependency-version-audit-plugin": "^0.1",
-                "magento/framework": "103.0.7-p4",
-                "magento/framework-amqp": "100.4.5",
-                "magento/framework-bulk": "101.0.3",
-                "magento/framework-message-queue": "100.4.7",
-                "magento/inventory-metapackage": "1.2.7-p4",
+                "magento/framework": "103.0.8-p1",
+                "magento/framework-amqp": "100.4.6",
+                "magento/framework-bulk": "101.0.4",
+                "magento/framework-message-queue": "100.4.8",
+                "magento/inventory-metapackage": "1.2.8-p1",
                 "magento/language-de_de": "100.4.0",
                 "magento/language-en_us": "100.4.0",
                 "magento/language-es_es": "100.4.0",
@@ -18731,239 +18699,240 @@
                 "magento/language-pt_br": "100.4.0",
                 "magento/language-zh_hans_cn": "100.4.0",
                 "magento/magento-composer-installer": ">=0.4.0",
-                "magento/magento2-base": "2.4.7-p4",
-                "magento/module-admin-analytics": "100.4.6",
-                "magento/module-admin-notification": "100.4.6-p3",
-                "magento/module-advanced-pricing-import-export": "100.4.7",
-                "magento/module-advanced-search": "100.4.5-p3",
-                "magento/module-amqp": "100.4.4",
-                "magento/module-analytics": "100.4.7",
-                "magento/module-application-performance-monitor": "100.4.0",
-                "magento/module-application-performance-monitor-new-relic": "100.4.0",
-                "magento/module-async-config": "100.4.0",
-                "magento/module-asynchronous-operations": "100.4.7",
-                "magento/module-authorization": "100.4.7",
-                "magento/module-aws-s3": "100.4.5",
-                "magento/module-backend": "102.0.7-p4",
-                "magento/module-backup": "100.4.7",
-                "magento/module-bundle": "101.0.7-p4",
-                "magento/module-bundle-graph-ql": "100.4.7",
-                "magento/module-bundle-import-export": "100.4.6",
-                "magento/module-cache-invalidate": "100.4.5",
-                "magento/module-captcha": "100.4.7",
-                "magento/module-cardinal-commerce": "100.4.5",
-                "magento/module-catalog": "104.0.7-p4",
-                "magento/module-catalog-analytics": "100.4.4",
-                "magento/module-catalog-cms-graph-ql": "100.4.3",
-                "magento/module-catalog-customer-graph-ql": "100.4.6",
-                "magento/module-catalog-graph-ql": "100.4.7",
-                "magento/module-catalog-import-export": "101.1.7-p3",
-                "magento/module-catalog-inventory": "100.4.7",
-                "magento/module-catalog-inventory-graph-ql": "100.4.4",
-                "magento/module-catalog-rule": "101.2.7",
-                "magento/module-catalog-rule-configurable": "100.4.6",
-                "magento/module-catalog-rule-graph-ql": "100.4.4",
-                "magento/module-catalog-search": "102.0.7-p3",
-                "magento/module-catalog-url-rewrite": "100.4.7",
-                "magento/module-catalog-url-rewrite-graph-ql": "100.4.5",
-                "magento/module-catalog-widget": "100.4.7",
-                "magento/module-checkout": "100.4.7",
-                "magento/module-checkout-agreements": "100.4.6",
-                "magento/module-checkout-agreements-graph-ql": "100.4.3",
-                "magento/module-cms": "104.0.7-p4",
-                "magento/module-cms-graph-ql": "100.4.4",
-                "magento/module-cms-url-rewrite": "100.4.6",
-                "magento/module-cms-url-rewrite-graph-ql": "100.4.5",
-                "magento/module-compare-list-graph-ql": "100.4.3",
-                "magento/module-config": "101.2.7-p4",
-                "magento/module-configurable-import-export": "100.4.5",
-                "magento/module-configurable-product": "100.4.7",
-                "magento/module-configurable-product-graph-ql": "100.4.7",
-                "magento/module-configurable-product-sales": "100.4.4",
-                "magento/module-contact": "100.4.6",
-                "magento/module-contact-graph-ql": "100.4.0",
-                "magento/module-cookie": "100.4.7",
-                "magento/module-cron": "100.4.7",
-                "magento/module-csp": "100.4.6",
-                "magento/module-currency-symbol": "100.4.5",
-                "magento/module-customer": "103.0.7-p4",
-                "magento/module-customer-analytics": "100.4.4",
-                "magento/module-customer-downloadable-graph-ql": "100.4.3",
-                "magento/module-customer-graph-ql": "100.4.7",
-                "magento/module-customer-import-export": "100.4.7",
-                "magento/module-deploy": "100.4.7",
-                "magento/module-developer": "100.4.7",
-                "magento/module-dhl": "100.4.6",
-                "magento/module-directory": "100.4.7-p4",
-                "magento/module-directory-graph-ql": "100.4.5",
-                "magento/module-downloadable": "100.4.7-p4",
-                "magento/module-downloadable-graph-ql": "100.4.7",
-                "magento/module-downloadable-import-export": "100.4.6",
-                "magento/module-eav": "102.1.7",
-                "magento/module-eav-graph-ql": "100.4.4",
-                "magento/module-elasticsearch": "101.0.7",
-                "magento/module-elasticsearch-7": "100.4.7",
-                "magento/module-email": "101.1.7-p4",
-                "magento/module-encryption-key": "100.4.5-p4",
-                "magento/module-fedex": "100.4.5-p2",
-                "magento/module-gift-message": "100.4.6",
-                "magento/module-gift-message-graph-ql": "100.4.5",
-                "magento/module-google-adwords": "100.4.4",
-                "magento/module-google-analytics": "100.4.3",
-                "magento/module-google-gtag": "100.4.2",
-                "magento/module-google-optimizer": "100.4.6",
-                "magento/module-graph-ql": "100.4.7",
-                "magento/module-graph-ql-cache": "100.4.4",
-                "magento/module-graph-ql-new-relic": "100.4.0",
-                "magento/module-graph-ql-resolver-cache": "100.4.0",
-                "magento/module-grouped-catalog-inventory": "100.4.4",
-                "magento/module-grouped-import-export": "100.4.5",
-                "magento/module-grouped-product": "100.4.7",
-                "magento/module-grouped-product-graph-ql": "100.4.7",
-                "magento/module-import-export": "101.0.7-p4",
-                "magento/module-indexer": "100.4.7",
-                "magento/module-instant-purchase": "100.4.6-p3",
-                "magento/module-integration": "100.4.7-p2",
-                "magento/module-integration-graph-ql": "100.4.0",
-                "magento/module-jwt-framework-adapter": "100.4.3",
-                "magento/module-jwt-user-token": "100.4.2-p2",
-                "magento/module-layered-navigation": "100.4.7",
-                "magento/module-login-as-customer": "100.4.7",
-                "magento/module-login-as-customer-admin-ui": "100.4.7",
-                "magento/module-login-as-customer-api": "100.4.6",
-                "magento/module-login-as-customer-assistance": "100.4.6",
-                "magento/module-login-as-customer-frontend-ui": "100.4.6",
-                "magento/module-login-as-customer-graph-ql": "100.4.4",
-                "magento/module-login-as-customer-log": "100.4.5",
-                "magento/module-login-as-customer-page-cache": "100.4.6",
-                "magento/module-login-as-customer-quote": "100.4.5",
-                "magento/module-login-as-customer-sales": "100.4.6",
-                "magento/module-marketplace": "100.4.5",
-                "magento/module-media-content": "100.4.5",
-                "magento/module-media-content-api": "100.4.6",
-                "magento/module-media-content-catalog": "100.4.5",
-                "magento/module-media-content-cms": "100.4.5",
-                "magento/module-media-content-synchronization": "100.4.6",
-                "magento/module-media-content-synchronization-api": "100.4.5",
-                "magento/module-media-content-synchronization-catalog": "100.4.4",
-                "magento/module-media-content-synchronization-cms": "100.4.4",
-                "magento/module-media-gallery": "100.4.6",
-                "magento/module-media-gallery-api": "101.0.6",
-                "magento/module-media-gallery-catalog": "100.4.4",
-                "magento/module-media-gallery-catalog-integration": "100.4.4",
-                "magento/module-media-gallery-catalog-ui": "100.4.4",
-                "magento/module-media-gallery-cms-ui": "100.4.4",
-                "magento/module-media-gallery-integration": "100.4.6",
-                "magento/module-media-gallery-metadata": "100.4.5",
-                "magento/module-media-gallery-metadata-api": "100.4.4",
-                "magento/module-media-gallery-renditions": "100.4.5",
-                "magento/module-media-gallery-renditions-api": "100.4.4",
-                "magento/module-media-gallery-synchronization": "100.4.6",
-                "magento/module-media-gallery-synchronization-api": "100.4.5",
-                "magento/module-media-gallery-synchronization-metadata": "100.4.3",
-                "magento/module-media-gallery-ui": "100.4.6",
-                "magento/module-media-gallery-ui-api": "100.4.5",
-                "magento/module-media-storage": "100.4.6",
-                "magento/module-message-queue": "100.4.7",
-                "magento/module-msrp": "100.4.6",
-                "magento/module-msrp-configurable-product": "100.4.4",
-                "magento/module-msrp-grouped-product": "100.4.4",
-                "magento/module-multishipping": "100.4.7",
-                "magento/module-mysql-mq": "100.4.5",
-                "magento/module-new-relic-reporting": "100.4.5",
-                "magento/module-newsletter": "100.4.7-p2",
-                "magento/module-newsletter-graph-ql": "100.4.4",
-                "magento/module-offline-payments": "100.4.5",
-                "magento/module-offline-shipping": "100.4.6",
-                "magento/module-open-search": "100.4.1",
-                "magento/module-order-cancellation": "100.4.0",
-                "magento/module-order-cancellation-graph-ql": "100.4.0",
-                "magento/module-order-cancellation-ui": "100.4.0-p4",
-                "magento/module-page-cache": "100.4.7",
-                "magento/module-payment": "100.4.7",
-                "magento/module-payment-graph-ql": "100.4.2",
-                "magento/module-paypal": "101.0.7-p3",
-                "magento/module-paypal-captcha": "100.4.4",
-                "magento/module-paypal-graph-ql": "100.4.5",
-                "magento/module-persistent": "100.4.7",
-                "magento/module-product-alert": "100.4.6",
-                "magento/module-product-video": "100.4.7",
-                "magento/module-quote": "101.2.7-p4",
-                "magento/module-quote-analytics": "100.4.6",
-                "magento/module-quote-bundle-options": "100.4.3",
-                "magento/module-quote-configurable-options": "100.4.3",
-                "magento/module-quote-downloadable-links": "100.4.3",
-                "magento/module-quote-graph-ql": "100.4.7",
-                "magento/module-related-product-graph-ql": "100.4.4",
-                "magento/module-release-notification": "100.4.5",
-                "magento/module-remote-storage": "100.4.5",
-                "magento/module-reports": "100.4.7-p4",
-                "magento/module-require-js": "100.4.3",
-                "magento/module-review": "100.4.7",
-                "magento/module-review-analytics": "100.4.4",
-                "magento/module-review-graph-ql": "100.4.3",
-                "magento/module-robots": "101.1.3",
-                "magento/module-rss": "100.4.5",
-                "magento/module-rule": "100.4.6",
-                "magento/module-sales": "103.0.7-p4",
-                "magento/module-sales-analytics": "100.4.4",
-                "magento/module-sales-graph-ql": "100.4.7",
-                "magento/module-sales-inventory": "100.4.4",
-                "magento/module-sales-rule": "101.2.7-p4",
-                "magento/module-sales-rule-graph-ql": "100.4.0",
-                "magento/module-sales-sequence": "100.4.4",
-                "magento/module-sample-data": "100.4.5",
-                "magento/module-search": "101.1.7-p3",
-                "magento/module-security": "100.4.7",
-                "magento/module-send-friend": "100.4.5",
-                "magento/module-send-friend-graph-ql": "100.4.3",
-                "magento/module-shipping": "100.4.7-p2",
-                "magento/module-sitemap": "100.4.6",
-                "magento/module-store": "101.1.7",
-                "magento/module-store-graph-ql": "100.4.5",
-                "magento/module-swagger": "100.4.6",
-                "magento/module-swagger-webapi": "100.4.3",
-                "magento/module-swagger-webapi-async": "100.4.3",
-                "magento/module-swatches": "100.4.7",
-                "magento/module-swatches-graph-ql": "100.4.5",
-                "magento/module-swatches-layered-navigation": "100.4.3",
-                "magento/module-tax": "100.4.7",
-                "magento/module-tax-graph-ql": "100.4.3",
-                "magento/module-tax-import-export": "100.4.6-p2",
-                "magento/module-theme": "101.1.7",
-                "magento/module-theme-graph-ql": "100.4.4",
-                "magento/module-translation": "100.4.7",
-                "magento/module-ui": "101.2.7-p4",
-                "magento/module-ups": "100.4.7-p1",
-                "magento/module-url-rewrite": "102.0.6",
-                "magento/module-url-rewrite-graph-ql": "100.4.6",
-                "magento/module-user": "101.2.7",
-                "magento/module-usps": "100.4.6-p3",
-                "magento/module-variable": "100.4.5",
-                "magento/module-vault": "101.2.7",
-                "magento/module-vault-graph-ql": "100.4.3",
-                "magento/module-version": "100.4.4",
-                "magento/module-webapi": "100.4.6-p1",
-                "magento/module-webapi-async": "100.4.5-p4",
-                "magento/module-webapi-security": "100.4.4",
-                "magento/module-weee": "100.4.7",
-                "magento/module-weee-graph-ql": "100.4.4",
-                "magento/module-widget": "101.2.7",
-                "magento/module-wishlist": "101.2.7-p3",
-                "magento/module-wishlist-analytics": "100.4.5",
-                "magento/module-wishlist-graph-ql": "100.4.7",
-                "magento/page-builder": "1.7.4-p4",
-                "magento/security-package": "1.1.6-p4",
-                "magento/theme-adminhtml-backend": "100.4.7-p3",
-                "magento/theme-frontend-blank": "100.4.7-p1",
-                "magento/theme-frontend-luma": "100.4.7-p1",
+                "magento/magento-zf-db": "^3.21",
+                "magento/magento2-base": "2.4.8-p1",
+                "magento/module-admin-analytics": "100.4.7",
+                "magento/module-admin-notification": "100.4.7",
+                "magento/module-advanced-pricing-import-export": "100.4.8",
+                "magento/module-advanced-search": "100.4.6",
+                "magento/module-amqp": "100.4.5",
+                "magento/module-analytics": "100.4.8",
+                "magento/module-application-performance-monitor": "100.4.1",
+                "magento/module-application-performance-monitor-new-relic": "100.4.1",
+                "magento/module-async-config": "100.4.1",
+                "magento/module-asynchronous-operations": "100.4.8",
+                "magento/module-authorization": "100.4.8",
+                "magento/module-aws-s3": "100.4.6",
+                "magento/module-backend": "102.0.8",
+                "magento/module-backup": "100.4.8",
+                "magento/module-bundle": "101.0.8",
+                "magento/module-bundle-graph-ql": "100.4.8",
+                "magento/module-bundle-import-export": "100.4.7",
+                "magento/module-cache-invalidate": "100.4.6",
+                "magento/module-captcha": "100.4.8",
+                "magento/module-cardinal-commerce": "100.4.6",
+                "magento/module-catalog": "104.0.8-p1",
+                "magento/module-catalog-analytics": "100.4.5",
+                "magento/module-catalog-cms-graph-ql": "100.4.4",
+                "magento/module-catalog-customer-graph-ql": "100.4.7",
+                "magento/module-catalog-graph-ql": "100.4.8",
+                "magento/module-catalog-import-export": "101.1.8",
+                "magento/module-catalog-inventory": "100.4.8",
+                "magento/module-catalog-inventory-graph-ql": "100.4.5",
+                "magento/module-catalog-rule": "101.2.8-p1",
+                "magento/module-catalog-rule-configurable": "100.4.7",
+                "magento/module-catalog-rule-graph-ql": "100.4.5-p1",
+                "magento/module-catalog-search": "102.0.8",
+                "magento/module-catalog-url-rewrite": "100.4.8",
+                "magento/module-catalog-url-rewrite-graph-ql": "100.4.6",
+                "magento/module-catalog-widget": "100.4.8",
+                "magento/module-checkout": "100.4.8",
+                "magento/module-checkout-agreements": "100.4.7",
+                "magento/module-checkout-agreements-graph-ql": "100.4.4",
+                "magento/module-cms": "104.0.8-p1",
+                "magento/module-cms-graph-ql": "100.4.5",
+                "magento/module-cms-url-rewrite": "100.4.7",
+                "magento/module-cms-url-rewrite-graph-ql": "100.4.6",
+                "magento/module-compare-list-graph-ql": "100.4.4",
+                "magento/module-config": "101.2.8",
+                "magento/module-configurable-import-export": "100.4.6",
+                "magento/module-configurable-product": "100.4.8",
+                "magento/module-configurable-product-graph-ql": "100.4.8",
+                "magento/module-configurable-product-sales": "100.4.5",
+                "magento/module-contact": "100.4.7",
+                "magento/module-contact-graph-ql": "100.4.1",
+                "magento/module-cookie": "100.4.8",
+                "magento/module-cron": "100.4.8",
+                "magento/module-csp": "100.4.7",
+                "magento/module-currency-symbol": "100.4.6",
+                "magento/module-customer": "103.0.8-p1",
+                "magento/module-customer-analytics": "100.4.5",
+                "magento/module-customer-downloadable-graph-ql": "100.4.4",
+                "magento/module-customer-graph-ql": "100.4.8-p1",
+                "magento/module-customer-import-export": "100.4.8",
+                "magento/module-deploy": "100.4.8",
+                "magento/module-developer": "100.4.8",
+                "magento/module-dhl": "100.4.7",
+                "magento/module-directory": "100.4.8",
+                "magento/module-directory-graph-ql": "100.4.6",
+                "magento/module-downloadable": "100.4.8-p1",
+                "magento/module-downloadable-graph-ql": "100.4.8",
+                "magento/module-downloadable-import-export": "100.4.7",
+                "magento/module-eav": "102.1.8",
+                "magento/module-eav-graph-ql": "100.4.5",
+                "magento/module-elasticsearch": "101.0.8",
+                "magento/module-elasticsearch-8": "101.0.0",
+                "magento/module-email": "101.1.8-p1",
+                "magento/module-encryption-key": "100.4.6",
+                "magento/module-fedex": "100.4.6",
+                "magento/module-gift-message": "100.4.7",
+                "magento/module-gift-message-graph-ql": "100.4.6",
+                "magento/module-google-adwords": "100.4.5",
+                "magento/module-google-analytics": "100.4.4",
+                "magento/module-google-gtag": "100.4.3",
+                "magento/module-google-optimizer": "100.4.7",
+                "magento/module-graph-ql": "100.4.8",
+                "magento/module-graph-ql-cache": "100.4.5",
+                "magento/module-graph-ql-new-relic": "100.4.1",
+                "magento/module-graph-ql-resolver-cache": "100.4.1",
+                "magento/module-grouped-catalog-inventory": "100.4.5",
+                "magento/module-grouped-import-export": "100.4.6",
+                "magento/module-grouped-product": "100.4.8",
+                "magento/module-grouped-product-graph-ql": "100.4.8",
+                "magento/module-import-export": "101.0.8",
+                "magento/module-indexer": "100.4.8",
+                "magento/module-instant-purchase": "100.4.7",
+                "magento/module-integration": "100.4.8",
+                "magento/module-integration-graph-ql": "100.4.1",
+                "magento/module-jwt-framework-adapter": "100.4.4",
+                "magento/module-jwt-user-token": "100.4.3",
+                "magento/module-layered-navigation": "100.4.8",
+                "magento/module-login-as-customer": "100.4.8",
+                "magento/module-login-as-customer-admin-ui": "100.4.8",
+                "magento/module-login-as-customer-api": "100.4.7",
+                "magento/module-login-as-customer-assistance": "100.4.7",
+                "magento/module-login-as-customer-frontend-ui": "100.4.7",
+                "magento/module-login-as-customer-graph-ql": "100.4.5",
+                "magento/module-login-as-customer-log": "100.4.6",
+                "magento/module-login-as-customer-page-cache": "100.4.7",
+                "magento/module-login-as-customer-quote": "100.4.6",
+                "magento/module-login-as-customer-sales": "100.4.7",
+                "magento/module-marketplace": "100.4.6",
+                "magento/module-media-content": "100.4.6",
+                "magento/module-media-content-api": "100.4.7",
+                "magento/module-media-content-catalog": "100.4.6",
+                "magento/module-media-content-cms": "100.4.6",
+                "magento/module-media-content-synchronization": "100.4.7",
+                "magento/module-media-content-synchronization-api": "100.4.6",
+                "magento/module-media-content-synchronization-catalog": "100.4.5",
+                "magento/module-media-content-synchronization-cms": "100.4.5",
+                "magento/module-media-gallery": "100.4.7",
+                "magento/module-media-gallery-api": "101.0.7",
+                "magento/module-media-gallery-catalog": "100.4.5",
+                "magento/module-media-gallery-catalog-integration": "100.4.5",
+                "magento/module-media-gallery-catalog-ui": "100.4.5",
+                "magento/module-media-gallery-cms-ui": "100.4.5",
+                "magento/module-media-gallery-integration": "100.4.7",
+                "magento/module-media-gallery-metadata": "100.4.6",
+                "magento/module-media-gallery-metadata-api": "100.4.5",
+                "magento/module-media-gallery-renditions": "100.4.6",
+                "magento/module-media-gallery-renditions-api": "100.4.5",
+                "magento/module-media-gallery-synchronization": "100.4.7",
+                "magento/module-media-gallery-synchronization-api": "100.4.6",
+                "magento/module-media-gallery-synchronization-metadata": "100.4.4",
+                "magento/module-media-gallery-ui": "100.4.7",
+                "magento/module-media-gallery-ui-api": "100.4.6",
+                "magento/module-media-storage": "100.4.7",
+                "magento/module-message-queue": "100.4.8",
+                "magento/module-msrp": "100.4.7",
+                "magento/module-msrp-configurable-product": "100.4.5",
+                "magento/module-msrp-grouped-product": "100.4.5",
+                "magento/module-multishipping": "100.4.8",
+                "magento/module-mysql-mq": "100.4.6",
+                "magento/module-new-relic-reporting": "100.4.6",
+                "magento/module-newsletter": "100.4.8",
+                "magento/module-newsletter-graph-ql": "100.4.5",
+                "magento/module-offline-payments": "100.4.6",
+                "magento/module-offline-shipping": "100.4.7",
+                "magento/module-open-search": "100.4.2",
+                "magento/module-order-cancellation": "100.4.1",
+                "magento/module-order-cancellation-graph-ql": "100.4.1",
+                "magento/module-order-cancellation-ui": "100.4.1",
+                "magento/module-page-cache": "100.4.8",
+                "magento/module-payment": "100.4.8",
+                "magento/module-payment-graph-ql": "100.4.3",
+                "magento/module-paypal": "101.0.8-p1",
+                "magento/module-paypal-captcha": "100.4.5",
+                "magento/module-paypal-graph-ql": "100.4.6",
+                "magento/module-persistent": "100.4.8",
+                "magento/module-product-alert": "100.4.7",
+                "magento/module-product-video": "100.4.8",
+                "magento/module-quote": "101.2.8-p1",
+                "magento/module-quote-analytics": "100.4.7",
+                "magento/module-quote-bundle-options": "100.4.4",
+                "magento/module-quote-configurable-options": "100.4.4",
+                "magento/module-quote-downloadable-links": "100.4.4",
+                "magento/module-quote-graph-ql": "100.4.8",
+                "magento/module-related-product-graph-ql": "100.4.5",
+                "magento/module-release-notification": "100.4.6",
+                "magento/module-remote-storage": "100.4.6",
+                "magento/module-reports": "100.4.8",
+                "magento/module-require-js": "100.4.4",
+                "magento/module-review": "100.4.8",
+                "magento/module-review-analytics": "100.4.5",
+                "magento/module-review-graph-ql": "100.4.4",
+                "magento/module-robots": "101.1.4",
+                "magento/module-rss": "100.4.6",
+                "magento/module-rule": "100.4.7",
+                "magento/module-sales": "103.0.8",
+                "magento/module-sales-analytics": "100.4.5",
+                "magento/module-sales-graph-ql": "100.4.8",
+                "magento/module-sales-inventory": "100.4.5",
+                "magento/module-sales-rule": "101.2.8-p1",
+                "magento/module-sales-rule-graph-ql": "100.4.1-p1",
+                "magento/module-sales-sequence": "100.4.5",
+                "magento/module-sample-data": "100.4.6",
+                "magento/module-search": "101.1.8",
+                "magento/module-security": "100.4.8",
+                "magento/module-send-friend": "100.4.6",
+                "magento/module-send-friend-graph-ql": "100.4.4",
+                "magento/module-shipping": "100.4.8-p1",
+                "magento/module-sitemap": "100.4.7",
+                "magento/module-store": "101.1.8",
+                "magento/module-store-graph-ql": "100.4.6",
+                "magento/module-swagger": "100.4.7",
+                "magento/module-swagger-webapi": "100.4.4",
+                "magento/module-swagger-webapi-async": "100.4.4",
+                "magento/module-swatches": "100.4.8",
+                "magento/module-swatches-graph-ql": "100.4.6",
+                "magento/module-swatches-layered-navigation": "100.4.4",
+                "magento/module-tax": "100.4.8",
+                "magento/module-tax-graph-ql": "100.4.4",
+                "magento/module-tax-import-export": "100.4.7",
+                "magento/module-theme": "101.1.8-p1",
+                "magento/module-theme-graph-ql": "100.4.5",
+                "magento/module-translation": "100.4.8",
+                "magento/module-ui": "101.2.8",
+                "magento/module-ups": "100.4.8",
+                "magento/module-url-rewrite": "102.0.7",
+                "magento/module-url-rewrite-graph-ql": "100.4.7",
+                "magento/module-user": "101.2.8-p1",
+                "magento/module-usps": "100.4.7",
+                "magento/module-variable": "100.4.6",
+                "magento/module-vault": "101.2.8",
+                "magento/module-vault-graph-ql": "100.4.4",
+                "magento/module-version": "100.4.5",
+                "magento/module-webapi": "100.4.7",
+                "magento/module-webapi-async": "100.4.6-p1",
+                "magento/module-webapi-security": "100.4.5",
+                "magento/module-weee": "100.4.8",
+                "magento/module-weee-graph-ql": "100.4.5",
+                "magento/module-widget": "101.2.8",
+                "magento/module-wishlist": "101.2.8",
+                "magento/module-wishlist-analytics": "100.4.6",
+                "magento/module-wishlist-graph-ql": "100.4.8",
+                "magento/page-builder": "1.7.5-p1",
+                "magento/security-package": "1.1.7-p1",
+                "magento/theme-adminhtml-backend": "100.4.8",
+                "magento/theme-frontend-blank": "100.4.8",
+                "magento/theme-frontend-luma": "100.4.8",
                 "magento/zend-cache": "^1.16",
                 "magento/zend-db": "^1.16",
                 "magento/zend-pdf": "^1.16",
-                "monolog/monolog": "^2.7",
-                "opensearch-project/opensearch-php": "^1.0 || ^2.0",
+                "monolog/monolog": "^3.6",
+                "opensearch-project/opensearch-php": "^2.3",
                 "pelago/emogrifier": "^7.0",
-                "php": "~8.1.0||~8.2.0||~8.3.0",
+                "php": "~8.2.0||~8.3.0||~8.4.0",
                 "php-amqplib/php-amqplib": "^3.2",
                 "phpseclib/mcrypt_compat": "^2.0",
                 "phpseclib/phpseclib": "^3.0",
@@ -18971,16 +18940,17 @@
                 "ramsey/uuid": "^4.2",
                 "symfony/console": "^6.4",
                 "symfony/intl": "^6.4",
+                "symfony/mailer": "^6.4",
+                "symfony/mime": "^6.4",
                 "symfony/process": "^6.4",
                 "symfony/string": "^6.4",
                 "tedivm/jshrink": "^1.4",
-                "tinymce/tinymce": "3.4.7",
                 "trentrichardson/jquery-timepicker-addon": "1.4.3",
                 "tubalmartin/cssmin": "^4.1",
                 "twbs/bootstrap": "3.1.0",
-                "web-token/jwt-framework": "^3.1",
+                "web-token/jwt-framework": "^3.4",
                 "webonyx/graphql-php": "^15.0",
-                "wikimedia/less.php": "^3.2"
+                "wikimedia/less.php": "^5.0"
             },
             "type": "metapackage",
             "license": [
@@ -18991,16 +18961,16 @@
         },
         {
             "name": "magento/quality-patches",
-            "version": "1.1.60",
+            "version": "1.1.67",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/quality-patches.git",
-                "reference": "65b2eac3c1da314d974b3965580caefe9867d71e"
+                "reference": "aa7a6e88cb82d174c179320597e3c496fe0d0cfd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/quality-patches/zipball/65b2eac3c1da314d974b3965580caefe9867d71e",
-                "reference": "65b2eac3c1da314d974b3965580caefe9867d71e",
+                "url": "https://api.github.com/repos/magento/quality-patches/zipball/aa7a6e88cb82d174c179320597e3c496fe0d0cfd",
+                "reference": "aa7a6e88cb82d174c179320597e3c496fe0d0cfd",
                 "shasum": ""
             },
             "require": {
@@ -19052,47 +19022,48 @@
             ],
             "description": "Provides quality patches for AdobeCommerce & Magento OpenSource",
             "support": {
-                "source": "https://github.com/magento/quality-patches/tree/1.1.60",
+                "source": "https://github.com/magento/quality-patches/tree/1.1.67",
                 "issues": "https://github.com/magento/quality-patches/issues"
             },
-            "time": "2025-02-25T18:26:27+00:00"
+            "time": "2025-06-27T18:55:01+00:00"
         },
         {
             "name": "magento/security-package",
-            "version": "1.1.6-p4",
+            "version": "1.1.7-p1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/security-package-1.1.6-p4.zip",
-                "shasum": "ad3c027a72486949d7d95d5539ba6080a9b227f5"
+                "url": "https://mirror.mage-os.org/packages/magento/security-package-1.1.7-p1.zip",
+                "shasum": "9b3ec81e4c9a5a3c41e7c93269f7cc7ac2188551"
             },
             "require": {
-                "google/recaptcha": "^1.2",
-                "magento/module-re-captcha-admin-ui": "1.1.4",
-                "magento/module-re-captcha-checkout": "1.1.4",
-                "magento/module-re-captcha-checkout-sales-rule": "1.1.3",
-                "magento/module-re-captcha-contact": "1.1.3",
-                "magento/module-re-captcha-customer": "1.1.5",
-                "magento/module-re-captcha-frontend-ui": "1.1.5",
-                "magento/module-re-captcha-migration": "1.1.4",
-                "magento/module-re-captcha-newsletter": "1.1.4",
-                "magento/module-re-captcha-paypal": "1.1.4",
-                "magento/module-re-captcha-review": "1.1.4",
-                "magento/module-re-captcha-send-friend": "1.1.4",
-                "magento/module-re-captcha-store-pickup": "1.0.3",
-                "magento/module-re-captcha-ui": "1.1.4",
-                "magento/module-re-captcha-user": "1.1.4",
-                "magento/module-re-captcha-validation": "1.1.3",
-                "magento/module-re-captcha-validation-api": "1.1.3",
-                "magento/module-re-captcha-version-2-checkbox": "2.0.4",
-                "magento/module-re-captcha-version-2-invisible": "2.0.4",
-                "magento/module-re-captcha-version-3-invisible": "2.0.4",
-                "magento/module-re-captcha-webapi-api": "1.0.3",
-                "magento/module-re-captcha-webapi-graph-ql": "1.0.3",
-                "magento/module-re-captcha-webapi-rest": "1.0.3",
-                "magento/module-re-captcha-webapi-ui": "1.0.3",
-                "magento/module-re-captcha-wishlist": "1.1.0-p4",
-                "magento/module-securitytxt": "1.1.3",
-                "magento/module-two-factor-auth": "1.1.6-p3"
+                "magento/module-re-captcha-admin-ui": "1.1.5",
+                "magento/module-re-captcha-checkout": "1.1.5",
+                "magento/module-re-captcha-checkout-sales-rule": "1.1.4",
+                "magento/module-re-captcha-contact": "1.1.4",
+                "magento/module-re-captcha-customer": "1.1.6",
+                "magento/module-re-captcha-frontend-ui": "1.1.6",
+                "magento/module-re-captcha-migration": "1.1.5",
+                "magento/module-re-captcha-newsletter": "1.1.5",
+                "magento/module-re-captcha-paypal": "1.1.5",
+                "magento/module-re-captcha-resend-confirmation-email": "1.1.0",
+                "magento/module-re-captcha-review": "1.1.5",
+                "magento/module-re-captcha-send-friend": "1.1.5",
+                "magento/module-re-captcha-store-pickup": "1.0.4",
+                "magento/module-re-captcha-ui": "1.1.5",
+                "magento/module-re-captcha-user": "1.1.5",
+                "magento/module-re-captcha-validation": "1.1.4",
+                "magento/module-re-captcha-validation-api": "1.1.4",
+                "magento/module-re-captcha-version-2-checkbox": "2.0.5",
+                "magento/module-re-captcha-version-2-invisible": "2.0.5",
+                "magento/module-re-captcha-version-3-invisible": "2.0.5",
+                "magento/module-re-captcha-webapi-api": "1.0.4",
+                "magento/module-re-captcha-webapi-graph-ql": "1.0.4",
+                "magento/module-re-captcha-webapi-rest": "1.0.4",
+                "magento/module-re-captcha-webapi-ui": "1.0.4",
+                "magento/module-re-captcha-wishlist": "1.1.4-p1",
+                "magento/module-securitytxt": "1.1.4",
+                "magento/module-two-factor-auth": "1.1.7",
+                "phpfui/recaptcha": "^2.0.0"
             },
             "type": "metapackage",
             "description": "Magento Security Package"
@@ -19128,11 +19099,11 @@
         },
         {
             "name": "magento/services-id",
-            "version": "3.2.7",
+            "version": "3.3.1",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/magento-services-id-3.2.7.0.zip",
-                "shasum": "89d25841fab7856f5ebe30a7233d38e9c8c4ce6d"
+                "url": "https://mirror.mage-os.org/packages/additional/magento-services-id-3.3.1.0.zip",
+                "shasum": "0fdc9ebc9014f349f8014abc21e3fa8f3ff0798f"
             },
             "require": {
                 "magento/framework": ">=102.0.0 <104.0.0",
@@ -19140,9 +19111,9 @@
                 "magento/module-backend": ">=101.0.0 <103.0.0",
                 "magento/module-config": ">=101.1.0 <101.3.0",
                 "magento/module-graph-ql-server": "^1.0.3",
-                "magento/module-services-id": "3.2.7",
-                "magento/module-services-id-graph-ql-server": "1.1.6",
-                "magento/module-services-id-layout": "1.1.4",
+                "magento/module-services-id": "3.3.1",
+                "magento/module-services-id-graph-ql-server": "1.1.8",
+                "magento/module-services-id-layout": "1.1.6",
                 "magento/module-store": ">=101.0.0 <101.2.0",
                 "magento/services-connector": "^1.3.6",
                 "php": "~7.2.0||~7.3.0||~7.4.0||~8.1.0||~8.2.0||~8.3.0||~8.4.0"
@@ -19156,15 +19127,15 @@
         },
         {
             "name": "magento/theme-adminhtml-backend",
-            "version": "100.4.7-p3",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/theme-adminhtml-backend-100.4.7-p3.zip",
-                "shasum": "15aa563e9ea3c299a8e22630c17d08e7d5a84352"
+                "url": "https://mirror.mage-os.org/packages/magento/theme-adminhtml-backend-100.4.8.zip",
+                "shasum": "0a8919cb340cde34db9a5f3f265ba7983d70b96b"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-theme",
             "autoload": {
@@ -19180,15 +19151,15 @@
         },
         {
             "name": "magento/theme-frontend-blank",
-            "version": "100.4.7-p1",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/theme-frontend-blank-100.4.7-p1.zip",
-                "shasum": "e8bc86ab2d18d1d2a931c7f4bf0a83ea19255c6e"
+                "url": "https://mirror.mage-os.org/packages/magento/theme-frontend-blank-100.4.8.zip",
+                "shasum": "96a516bc4d57ca57bcb2ea990af30c415b9548cf"
             },
             "require": {
                 "magento/framework": "103.0.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-theme",
             "autoload": {
@@ -19204,16 +19175,16 @@
         },
         {
             "name": "magento/theme-frontend-luma",
-            "version": "100.4.7-p1",
+            "version": "100.4.8",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/magento/theme-frontend-luma-100.4.7-p1.zip",
-                "shasum": "d17844b913100b2dfc408154e4c2afad99d8294f"
+                "url": "https://mirror.mage-os.org/packages/magento/theme-frontend-luma-100.4.8.zip",
+                "shasum": "bafe06164901f04400972c5872f366d0db05182d"
             },
             "require": {
                 "magento/framework": "103.0.*",
                 "magento/theme-frontend-blank": "100.4.*",
-                "php": "~8.1.0||~8.2.0||~8.3.0"
+                "php": "~8.2.0||~8.3.0||~8.4.0"
             },
             "type": "magento2-theme",
             "autoload": {
@@ -19537,16 +19508,16 @@
         },
         {
             "name": "magento/zend-pdf",
-            "version": "1.16.4",
+            "version": "1.16.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/magento/magento-zend-pdf.git",
-                "reference": "b6e9fcbec29184bb4eb6fa4a261a79d5d92f7ff8"
+                "reference": "ce8e838cf04a41f5b2659509d628edf1416e4fbe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/magento/magento-zend-pdf/zipball/b6e9fcbec29184bb4eb6fa4a261a79d5d92f7ff8",
-                "reference": "b6e9fcbec29184bb4eb6fa4a261a79d5d92f7ff8",
+                "url": "https://api.github.com/repos/magento/magento-zend-pdf/zipball/ce8e838cf04a41f5b2659509d628edf1416e4fbe",
+                "reference": "ce8e838cf04a41f5b2659509d628edf1416e4fbe",
                 "shasum": ""
             },
             "require": {
@@ -19588,9 +19559,82 @@
             ],
             "support": {
                 "issues": "https://github.com/magento/magento-zend-pdf/issues",
-                "source": "https://github.com/magento/magento-zend-pdf/tree/1.16.4"
+                "source": "https://github.com/magento/magento-zend-pdf/tree/1.16.5"
             },
-            "time": "2024-12-18T14:59:28+00:00"
+            "time": "2025-06-20T07:55:02+00:00"
+        },
+        {
+            "name": "marc-mabe/php-enum",
+            "version": "v4.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/marc-mabe/php-enum.git",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/marc-mabe/php-enum/zipball/7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "reference": "7159809e5cfa041dca28e61f7f7ae58063aae8ed",
+                "shasum": ""
+            },
+            "require": {
+                "ext-reflection": "*",
+                "php": "^7.1 | ^8.0"
+            },
+            "require-dev": {
+                "phpbench/phpbench": "^0.16.10 || ^1.0.4",
+                "phpstan/phpstan": "^1.3.1",
+                "phpunit/phpunit": "^7.5.20 | ^8.5.22 | ^9.5.11",
+                "vimeo/psalm": "^4.17.0 | ^5.26.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-3.x": "3.2-dev",
+                    "dev-master": "4.7-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MabeEnum\\": "src/"
+                },
+                "classmap": [
+                    "stubs/Stringable.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Marc Bennewitz",
+                    "email": "dev@mabe.berlin",
+                    "homepage": "https://mabe.berlin/",
+                    "role": "Lead"
+                }
+            ],
+            "description": "Simple and fast implementation of enumerations with native PHP",
+            "homepage": "https://github.com/marc-mabe/php-enum",
+            "keywords": [
+                "enum",
+                "enum-map",
+                "enum-set",
+                "enumeration",
+                "enumerator",
+                "enummap",
+                "enumset",
+                "map",
+                "set",
+                "type",
+                "type-hint",
+                "typehint"
+            ],
+            "support": {
+                "issues": "https://github.com/marc-mabe/php-enum/issues",
+                "source": "https://github.com/marc-mabe/php-enum/tree/v4.7.1"
+            },
+            "time": "2024-11-28T04:54:44+00:00"
         },
         {
             "name": "markshust/magento2-module-disabletwofactorauth",
@@ -19646,42 +19690,43 @@
         },
         {
             "name": "monolog/monolog",
-            "version": "2.10.0",
+            "version": "3.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Seldaek/monolog.git",
-                "reference": "5cf826f2991858b54d5c3809bee745560a1042a7"
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/5cf826f2991858b54d5c3809bee745560a1042a7",
-                "reference": "5cf826f2991858b54d5c3809bee745560a1042a7",
+                "url": "https://api.github.com/repos/Seldaek/monolog/zipball/10d85740180ecba7896c87e06a166e0c95a0e3b6",
+                "reference": "10d85740180ecba7896c87e06a166e0c95a0e3b6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2",
-                "psr/log": "^1.0.1 || ^2.0 || ^3.0"
+                "php": ">=8.1",
+                "psr/log": "^2.0 || ^3.0"
             },
             "provide": {
-                "psr/log-implementation": "1.0.0 || 2.0.0 || 3.0.0"
+                "psr/log-implementation": "3.0.0"
             },
             "require-dev": {
-                "aws/aws-sdk-php": "^2.4.9 || ^3.0",
+                "aws/aws-sdk-php": "^3.0",
                 "doctrine/couchdb": "~1.0@dev",
                 "elasticsearch/elasticsearch": "^7 || ^8",
                 "ext-json": "*",
-                "graylog2/gelf-php": "^1.4.2 || ^2@dev",
-                "guzzlehttp/guzzle": "^7.4",
+                "graylog2/gelf-php": "^1.4.2 || ^2.0",
+                "guzzlehttp/guzzle": "^7.4.5",
                 "guzzlehttp/psr7": "^2.2",
                 "mongodb/mongodb": "^1.8",
                 "php-amqplib/php-amqplib": "~2.4 || ^3",
-                "phpspec/prophecy": "^1.15",
-                "phpstan/phpstan": "^1.10",
-                "phpunit/phpunit": "^8.5.38 || ^9.6.19",
-                "predis/predis": "^1.1 || ^2.0",
-                "rollbar/rollbar": "^1.3 || ^2 || ^3",
-                "ruflin/elastica": "^7",
-                "swiftmailer/swiftmailer": "^5.3|^6.0",
+                "php-console/php-console": "^3.1.8",
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^10.5.17 || ^11.0.7",
+                "predis/predis": "^1.1 || ^2",
+                "rollbar/rollbar": "^4.0",
+                "ruflin/elastica": "^7 || ^8",
                 "symfony/mailer": "^5.4 || ^6",
                 "symfony/mime": "^5.4 || ^6"
             },
@@ -19704,7 +19749,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.x-dev"
+                    "dev-main": "3.x-dev"
                 }
             },
             "autoload": {
@@ -19732,7 +19777,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Seldaek/monolog/issues",
-                "source": "https://github.com/Seldaek/monolog/tree/2.10.0"
+                "source": "https://github.com/Seldaek/monolog/tree/3.9.0"
             },
             "funding": [
                 {
@@ -19744,7 +19789,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T12:43:37+00:00"
+            "time": "2025-03-24T10:02:05+00:00"
         },
         {
             "name": "mtdowling/jmespath.php",
@@ -19814,16 +19859,16 @@
         },
         {
             "name": "n98/magerun2-dist",
-            "version": "8.0.0",
+            "version": "9.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/netz98/n98-magerun2-dist.git",
-                "reference": "2e508362b597382239634b361b95790312c25ef4"
+                "reference": "ce253596ca58579360ff6a63a5b0b6c74fc4186e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/netz98/n98-magerun2-dist/zipball/2e508362b597382239634b361b95790312c25ef4",
-                "reference": "2e508362b597382239634b361b95790312c25ef4",
+                "url": "https://api.github.com/repos/netz98/n98-magerun2-dist/zipball/ce253596ca58579360ff6a63a5b0b6c74fc4186e",
+                "reference": "ce253596ca58579360ff6a63a5b0b6c74fc4186e",
                 "shasum": ""
             },
             "require": {
@@ -19850,22 +19895,22 @@
             ],
             "support": {
                 "issues": "https://github.com/netz98/n98-magerun2/issues",
-                "source": "https://github.com/netz98/n98-magerun2-dist/tree/8.0.0"
+                "source": "https://github.com/netz98/n98-magerun2-dist/tree/9.0.1"
             },
-            "time": "2025-02-24T08:57:46+00:00"
+            "time": "2025-06-24T12:18:03+00:00"
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.8.6",
+            "version": "3.10.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "ff2f20cf83bd4d503720632ce8a426dc747bf7fd"
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/ff2f20cf83bd4d503720632ce8a426dc747bf7fd",
-                "reference": "ff2f20cf83bd4d503720632ce8a426dc747bf7fd",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
+                "reference": "1fd1935b2d90aef2f093c5e35f7ae1257c448d00",
                 "shasum": ""
             },
             "require": {
@@ -19873,9 +19918,9 @@
                 "ext-json": "*",
                 "php": "^8.1",
                 "psr/clock": "^1.0",
-                "symfony/clock": "^6.3 || ^7.0",
+                "symfony/clock": "^6.3.12 || ^7.0",
                 "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation": "^4.4.18 || ^5.2.1|| ^6.0 || ^7.0"
+                "symfony/translation": "^4.4.18 || ^5.2.1 || ^6.0 || ^7.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -19883,14 +19928,13 @@
             "require-dev": {
                 "doctrine/dbal": "^3.6.3 || ^4.0",
                 "doctrine/orm": "^2.15.2 || ^3.0",
-                "friendsofphp/php-cs-fixer": "^3.57.2",
+                "friendsofphp/php-cs-fixer": "^3.75.0",
                 "kylekatarnls/multi-tester": "^2.5.3",
-                "ondrejmirtes/better-reflection": "^6.25.0.4",
                 "phpmd/phpmd": "^2.15.0",
-                "phpstan/extension-installer": "^1.3.1",
-                "phpstan/phpstan": "^1.11.2",
-                "phpunit/phpunit": "^10.5.20",
-                "squizlabs/php_codesniffer": "^3.9.0"
+                "phpstan/extension-installer": "^1.4.3",
+                "phpstan/phpstan": "^2.1.17",
+                "phpunit/phpunit": "^10.5.46",
+                "squizlabs/php_codesniffer": "^3.13.0"
             },
             "bin": [
                 "bin/carbon"
@@ -19958,20 +20002,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-20T17:33:38+00:00"
+            "time": "2025-06-21T15:19:35+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.4.0",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494"
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/447a020a1f875a434d62f2a401f53b82a396e494",
-                "reference": "447a020a1f875a434d62f2a401f53b82a396e494",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/ae59794362fe85e051a58ad36b289443f57be7a9",
+                "reference": "ae59794362fe85e051a58ad36b289443f57be7a9",
                 "shasum": ""
             },
             "require": {
@@ -20014,9 +20058,138 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.4.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.5.0"
             },
-            "time": "2024-12-30T11:07:19+00:00"
+            "time": "2025-05-31T08:24:38+00:00"
+        },
+        {
+            "name": "open-telemetry/api",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/api.git",
+                "reference": "b3a9286f9c1c8247c83493c5b1fa475cd0cec7f7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/api/zipball/b3a9286f9c1c8247c83493c5b1fa475cd0cec7f7",
+                "reference": "b3a9286f9c1c8247c83493c5b1fa475cd0cec7f7",
+                "shasum": ""
+            },
+            "require": {
+                "open-telemetry/context": "^1.0",
+                "php": "^8.1",
+                "psr/log": "^1.1|^2.0|^3.0",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "conflict": {
+                "open-telemetry/sdk": "<=1.0.8"
+            },
+            "type": "library",
+            "extra": {
+                "spi": {
+                    "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\HookManagerInterface": [
+                        "OpenTelemetry\\API\\Instrumentation\\AutoInstrumentation\\ExtensionHookManager"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-main": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "Trace/functions.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\API\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "API for OpenTelemetry PHP.",
+            "keywords": [
+                "Metrics",
+                "api",
+                "apm",
+                "logging",
+                "opentelemetry",
+                "otel",
+                "tracing"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2025-06-19T23:36:51+00:00"
+        },
+        {
+            "name": "open-telemetry/context",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/opentelemetry-php/context.git",
+                "reference": "1eb2b837ee9362db064a6b65d5ecce15a9f9f020"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/opentelemetry-php/context/zipball/1eb2b837ee9362db064a6b65d5ecce15a9f9f020",
+                "reference": "1eb2b837ee9362db064a6b65d5ecce15a9f9f020",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^8.1",
+                "symfony/polyfill-php82": "^1.26"
+            },
+            "suggest": {
+                "ext-ffi": "To allow context switching in Fibers"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "fiber/initialize_fiber_handler.php"
+                ],
+                "psr-4": {
+                    "OpenTelemetry\\Context\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "opentelemetry-php contributors",
+                    "homepage": "https://github.com/open-telemetry/opentelemetry-php/graphs/contributors"
+                }
+            ],
+            "description": "Context implementation for OpenTelemetry PHP.",
+            "keywords": [
+                "Context",
+                "opentelemetry",
+                "otel"
+            ],
+            "support": {
+                "chat": "https://app.slack.com/client/T08PSQ7BQ/C01NFPCV44V",
+                "docs": "https://opentelemetry.io/docs/php",
+                "issues": "https://github.com/open-telemetry/opentelemetry-php/issues",
+                "source": "https://github.com/open-telemetry/opentelemetry-php"
+            },
+            "time": "2025-05-07T23:36:50+00:00"
         },
         {
             "name": "opensearch-project/opensearch-php",
@@ -20312,20 +20485,20 @@
         },
         {
             "name": "paypal/module-braintree",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-4.6.1.0-patch3.zip",
-                "shasum": "864561fdf376966f6f52151b7a680954d5c67978"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-4.6.1.0-patch5.zip",
+                "shasum": "9b85085f6dd3afbf37b89138930378da6963dd7b"
             },
             "require": {
-                "braintree/braintree_php": "6.13.0",
+                "braintree/braintree_php": "6.21.0",
                 "magento/framework": "*",
-                "paypal/module-braintree-core": "4.6.1-p3",
-                "paypal/module-braintree-customer-balance": "4.6.1-p3",
-                "paypal/module-braintree-gift-card-account": "4.6.1-p3",
-                "paypal/module-braintree-gift-wrapping": "4.6.1-p3",
-                "paypal/module-braintree-graph-ql": "4.6.1-p3",
+                "paypal/module-braintree-core": "4.6.1-p5",
+                "paypal/module-braintree-customer-balance": "4.6.1-p5",
+                "paypal/module-braintree-gift-card-account": "4.6.1-p5",
+                "paypal/module-braintree-gift-wrapping": "4.6.1-p5",
+                "paypal/module-braintree-graph-ql": "4.6.1-p5",
                 "php": "~8.1.0||~8.2.0||~8.3.0"
             },
             "require-dev": {
@@ -20339,14 +20512,14 @@
         },
         {
             "name": "paypal/module-braintree-core",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-core-4.6.1.0-patch3.zip",
-                "shasum": "103e37facd2b6f7c4e0cb88ab1fc0b3ed978f626"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-core-4.6.1.0-patch5.zip",
+                "shasum": "830661fe693863af4cd20c38a948ebe97fd5728b"
             },
             "require": {
-                "braintree/braintree_php": "6.13.0",
+                "braintree/braintree_php": "6.21.0",
                 "ext-json": "*",
                 "ext-simplexml": "*",
                 "magento/framework": "*",
@@ -20407,17 +20580,17 @@
         },
         {
             "name": "paypal/module-braintree-customer-balance",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-customer-balance-4.6.1.0-patch3.zip",
-                "shasum": "9468afa476d564050d84da27c0596e32723fdbcc"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-customer-balance-4.6.1.0-patch5.zip",
+                "shasum": "92f281784141dec6cc997e0057e46e3faa76a695"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-quote": "101.0.*||101.1.*||^101.2.0",
                 "magento/module-sales": "101.0.*||102.0.*||^102.1.0||^103",
-                "paypal/module-braintree-core": "4.6.1-p3",
+                "paypal/module-braintree-core": "4.6.1-p5",
                 "php": "~8.1.0||~8.2.0||~8.3.0"
             },
             "suggest": {
@@ -20440,17 +20613,17 @@
         },
         {
             "name": "paypal/module-braintree-gift-card-account",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-gift-card-account-4.6.1.0-patch3.zip",
-                "shasum": "2ec37b1848d3c7eb927f047d55879cda3a0e6463"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-gift-card-account-4.6.1.0-patch5.zip",
+                "shasum": "712be241dff7a85623b137dd8ab46c9df20bf602"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-quote": "101.0.*||101.1.*||^101.2.0",
                 "magento/module-sales": "101.0.*||102.0.*||^102.1.0||^103",
-                "paypal/module-braintree-core": "4.6.1-p3",
+                "paypal/module-braintree-core": "4.6.1-p5",
                 "php": "~8.1.0||~8.2.0||~8.3.0"
             },
             "suggest": {
@@ -20473,17 +20646,17 @@
         },
         {
             "name": "paypal/module-braintree-gift-wrapping",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-gift-wrapping-4.6.1.0-patch3.zip",
-                "shasum": "8d28e5bb10937372d758f53dd9baecc30dcf5a09"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-gift-wrapping-4.6.1.0-patch5.zip",
+                "shasum": "5a9365fab80ca7432d16485531b51a1064b2230c"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-quote": "101.0.*||101.1.*||^101.2.0",
                 "magento/module-sales": "101.0.*||102.0.*||^102.1.0||^103",
-                "paypal/module-braintree-core": "4.6.1-p3",
+                "paypal/module-braintree-core": "4.6.1-p5",
                 "php": "~8.1.0||~8.2.0||~8.3.0"
             },
             "suggest": {
@@ -20506,18 +20679,18 @@
         },
         {
             "name": "paypal/module-braintree-graph-ql",
-            "version": "4.6.1-p3",
+            "version": "4.6.1-p5",
             "dist": {
                 "type": "zip",
-                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-graph-ql-4.6.1.0-patch3.zip",
-                "shasum": "3793044c9ba6ebe9e1ab50bee9e9df1306e73832"
+                "url": "https://mirror.mage-os.org/packages/additional/paypal-module-braintree-graph-ql-4.6.1.0-patch5.zip",
+                "shasum": "fb1f92040a421db6b2da621f361194d5fb558c01"
             },
             "require": {
                 "magento/framework": "*",
                 "magento/module-quote": "^101",
                 "magento/module-quote-graph-ql": "^100",
                 "magento/module-store": "^101",
-                "paypal/module-braintree-core": "4.6.1-p3",
+                "paypal/module-braintree-core": "4.6.1-p5",
                 "php": "~8.1.0||~8.2.0||~8.3.0"
             },
             "require-dev": {
@@ -20625,22 +20798,22 @@
         },
         {
             "name": "php-amqplib/php-amqplib",
-            "version": "v3.2.0",
+            "version": "v3.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-amqplib/php-amqplib.git",
-                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e"
+                "reference": "9f50fe69a9f1a19e2cb25596a354d705de36fe59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/0bec5b392428e0ac3b3f34fbc4e02d706995833e",
-                "reference": "0bec5b392428e0ac3b3f34fbc4e02d706995833e",
+                "url": "https://api.github.com/repos/php-amqplib/php-amqplib/zipball/9f50fe69a9f1a19e2cb25596a354d705de36fe59",
+                "reference": "9f50fe69a9f1a19e2cb25596a354d705de36fe59",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
                 "ext-sockets": "*",
-                "php": "^7.1||^8.0",
+                "php": "^7.2||^8.0",
                 "phpseclib/phpseclib": "^2.0|^3.0"
             },
             "conflict": {
@@ -20700,9 +20873,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-amqplib/php-amqplib/issues",
-                "source": "https://github.com/php-amqplib/php-amqplib/tree/v3.2.0"
+                "source": "https://github.com/php-amqplib/php-amqplib/tree/v3.7.3"
             },
-            "time": "2022-03-10T19:16:00+00:00"
+            "time": "2025-02-18T20:11:13+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -20784,6 +20957,162 @@
             "time": "2024-10-02T11:20:13+00:00"
         },
         {
+            "name": "php-http/httplug",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/httplug.git",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/httplug/zipball/5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "reference": "5cad731844891a4c282f3f3e1b582c46839d22f4",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "php-http/promise": "^1.1",
+                "psr/http-client": "^1.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.1 || ^5.0 || ^6.0",
+                "phpspec/phpspec": "^5.1 || ^6.0 || ^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Eric GELOEN",
+                    "email": "geloen.eric@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com",
+                    "homepage": "https://sagikazarmark.hu"
+                }
+            ],
+            "description": "HTTPlug, the HTTP client abstraction for PHP",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "client",
+                "http"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/httplug/issues",
+                "source": "https://github.com/php-http/httplug/tree/2.4.1"
+            },
+            "time": "2024-09-23T11:39:58+00:00"
+        },
+        {
+            "name": "php-http/promise",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/promise.git",
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/promise/zipball/fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
+                "reference": "fc85b1fba37c169a69a07ef0d5a8075770cc1f83",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "friends-of-phpspec/phpspec-code-coverage": "^4.3.2 || ^6.3",
+                "phpspec/phpspec": "^5.1.2 || ^6.2 || ^7.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Http\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Joel Wurtz",
+                    "email": "joel.wurtz@gmail.com"
+                },
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Promise used for asynchronous HTTP requests",
+            "homepage": "http://httplug.io",
+            "keywords": [
+                "promise"
+            ],
+            "support": {
+                "issues": "https://github.com/php-http/promise/issues",
+                "source": "https://github.com/php-http/promise/tree/1.3.1"
+            },
+            "time": "2024-03-15T13:55:21+00:00"
+        },
+        {
+            "name": "phpfui/recaptcha",
+            "version": "V2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpfui/recaptcha.git",
+                "reference": "2fa89004beaa8665a8c9109ab95d870354802d5d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpfui/recaptcha/zipball/2fa89004beaa8665a8c9109ab95d870354802d5d",
+                "reference": "2fa89004beaa8665a8c9109ab95d870354802d5d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.14",
+                "php-coveralls/php-coveralls": "^2.5",
+                "phpstan/phpstan": "^2.1",
+                "phpunit/phpunit": "^11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ReCaptcha\\": "src/ReCaptcha"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Client library for Google's reCAPTCHA for PHP 8.4 and higher",
+            "homepage": "https://www.google.com/recaptcha/",
+            "keywords": [
+                "Abuse",
+                "captcha",
+                "recaptcha",
+                "spam"
+            ],
+            "support": {
+                "forum": "https://groups.google.com/forum/#!forum/recaptcha",
+                "source": "https://github.com/phpfui/recaptcha"
+            },
+            "time": "2025-01-09T22:31:40+00:00"
+        },
+        {
             "name": "phpgt/cssxpath",
             "version": "v1.3.0",
             "source": {
@@ -20839,16 +21168,16 @@
         },
         {
             "name": "phpgt/dom",
-            "version": "v4.1.7",
+            "version": "v4.1.8",
             "source": {
                 "type": "git",
-                "url": "https://github.com/PhpGt/Dom.git",
-                "reference": "2de9031c477e1eabe9e26c3412610a45c9b6b14d"
+                "url": "https://github.com/phpgt/Dom.git",
+                "reference": "dfe4843e402b018141db50a3cf1fbe19406390c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PhpGt/Dom/zipball/2de9031c477e1eabe9e26c3412610a45c9b6b14d",
-                "reference": "2de9031c477e1eabe9e26c3412610a45c9b6b14d",
+                "url": "https://api.github.com/repos/phpgt/Dom/zipball/dfe4843e402b018141db50a3cf1fbe19406390c5",
+                "reference": "dfe4843e402b018141db50a3cf1fbe19406390c5",
                 "shasum": ""
             },
             "require": {
@@ -20926,8 +21255,8 @@
             ],
             "description": "Modern DOM API.",
             "support": {
-                "issues": "https://github.com/PhpGt/Dom/issues",
-                "source": "https://github.com/PhpGt/Dom/tree/v4.1.7"
+                "issues": "https://github.com/phpgt/Dom/issues",
+                "source": "https://github.com/phpgt/Dom/tree/v4.1.8"
             },
             "funding": [
                 {
@@ -20935,7 +21264,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-01-02T23:56:16+00:00"
+            "time": "2025-04-21T13:43:50+00:00"
         },
         {
             "name": "phpgt/propfunc",
@@ -21059,16 +21388,16 @@
         },
         {
             "name": "phpseclib/phpseclib",
-            "version": "3.0.43",
+            "version": "3.0.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpseclib/phpseclib.git",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02"
+                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/709ec107af3cb2f385b9617be72af8cf62441d02",
-                "reference": "709ec107af3cb2f385b9617be72af8cf62441d02",
+                "url": "https://api.github.com/repos/phpseclib/phpseclib/zipball/56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
+                "reference": "56483a7de62a6c2a6635e42e93b8a9e25d4f0ec6",
                 "shasum": ""
             },
             "require": {
@@ -21149,7 +21478,7 @@
             ],
             "support": {
                 "issues": "https://github.com/phpseclib/phpseclib/issues",
-                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.43"
+                "source": "https://github.com/phpseclib/phpseclib/tree/3.0.46"
             },
             "funding": [
                 {
@@ -21165,7 +21494,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-14T21:12:59+00:00"
+            "time": "2025-06-26T16:29:55+00:00"
         },
         {
             "name": "psr/cache",
@@ -21669,16 +21998,16 @@
         },
         {
             "name": "ramsey/collection",
-            "version": "2.1.0",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/collection.git",
-                "reference": "3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109"
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/collection/zipball/3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109",
-                "reference": "3c5990b8a5e0b79cd1cf11c2dc1229e58e93f109",
+                "url": "https://api.github.com/repos/ramsey/collection/zipball/344572933ad0181accbf4ba763e85a0306a8c5e2",
+                "reference": "344572933ad0181accbf4ba763e85a0306a8c5e2",
                 "shasum": ""
             },
             "require": {
@@ -21739,27 +22068,26 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/collection/issues",
-                "source": "https://github.com/ramsey/collection/tree/2.1.0"
+                "source": "https://github.com/ramsey/collection/tree/2.1.1"
             },
-            "time": "2025-03-02T04:48:29+00:00"
+            "time": "2025-03-22T05:38:12+00:00"
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.7.6",
+            "version": "4.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088"
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/91039bc1faa45ba123c4328958e620d382ec7088",
-                "reference": "91039bc1faa45ba123c4328958e620d382ec7088",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/4e0e23cc785f0724a0e838279a9eb03f28b092a0",
+                "reference": "4e0e23cc785f0724a0e838279a9eb03f28b092a0",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12",
-                "ext-json": "*",
+                "brick/math": "^0.8.8 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -21767,26 +22095,23 @@
                 "rhumsaa/uuid": "self.version"
             },
             "require-dev": {
-                "captainhook/captainhook": "^5.10",
+                "captainhook/captainhook": "^5.25",
                 "captainhook/plugin-composer": "^5.3",
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
-                "doctrine/annotations": "^1.8",
-                "ergebnis/composer-normalize": "^2.15",
-                "mockery/mockery": "^1.3",
+                "dealerdirect/phpcodesniffer-composer-installer": "^1.0",
+                "ergebnis/composer-normalize": "^2.47",
+                "mockery/mockery": "^1.6",
                 "paragonie/random-lib": "^2",
-                "php-mock/php-mock": "^2.2",
-                "php-mock/php-mock-mockery": "^1.3",
-                "php-parallel-lint/php-parallel-lint": "^1.1",
-                "phpbench/phpbench": "^1.0",
-                "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "^1.8",
-                "phpstan/phpstan-mockery": "^1.1",
-                "phpstan/phpstan-phpunit": "^1.1",
-                "phpunit/phpunit": "^8.5 || ^9",
-                "ramsey/composer-repl": "^1.4",
-                "slevomat/coding-standard": "^8.4",
-                "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^4.9"
+                "php-mock/php-mock": "^2.6",
+                "php-mock/php-mock-mockery": "^1.5",
+                "php-parallel-lint/php-parallel-lint": "^1.4.0",
+                "phpbench/phpbench": "^1.2.14",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-mockery": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "slevomat/coding-standard": "^8.18",
+                "squizlabs/php_codesniffer": "^3.13"
             },
             "suggest": {
                 "ext-bcmath": "Enables faster math with arbitrary-precision integers using BCMath.",
@@ -21821,19 +22146,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.7.6"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.0"
             },
-            "funding": [
-                {
-                    "url": "https://github.com/ramsey",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/ramsey/uuid",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-04-27T21:32:50+00:00"
+            "time": "2025-06-25T14:20:11+00:00"
         },
         {
             "name": "react/promise",
@@ -21910,16 +22225,16 @@
         },
         {
             "name": "sabberworm/php-css-parser",
-            "version": "v8.7.0",
+            "version": "v8.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/MyIntervals/PHP-CSS-Parser.git",
-                "reference": "f414ff953002a9b18e3a116f5e462c56f21237cf"
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/f414ff953002a9b18e3a116f5e462c56f21237cf",
-                "reference": "f414ff953002a9b18e3a116f5e462c56f21237cf",
+                "url": "https://api.github.com/repos/MyIntervals/PHP-CSS-Parser/zipball/d8e916507b88e389e26d4ab03c904a082aa66bb9",
+                "reference": "d8e916507b88e389e26d4ab03c904a082aa66bb9",
                 "shasum": ""
             },
             "require": {
@@ -21927,7 +22242,8 @@
                 "php": "^5.6.20 || ^7.0.0 || ~8.0.0 || ~8.1.0 || ~8.2.0 || ~8.3.0 || ~8.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.40"
+                "phpunit/phpunit": "5.7.27 || 6.5.14 || 7.5.20 || 8.5.41",
+                "rawr/cross-data-providers": "^2.0.0"
             },
             "suggest": {
                 "ext-mbstring": "for parsing UTF-8 CSS"
@@ -21969,9 +22285,9 @@
             ],
             "support": {
                 "issues": "https://github.com/MyIntervals/PHP-CSS-Parser/issues",
-                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.7.0"
+                "source": "https://github.com/MyIntervals/PHP-CSS-Parser/tree/v8.9.0"
             },
-            "time": "2024-10-27T17:38:32+00:00"
+            "time": "2025-07-11T13:20:48+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -22306,20 +22622,20 @@
         },
         {
             "name": "spomky-labs/pki-framework",
-            "version": "1.2.2",
+            "version": "1.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/pki-framework.git",
-                "reference": "5ac374c3e295c8b917208ff41b4d30f76668478c"
+                "reference": "eced5b5ce70518b983ff2be486e902bbd15135ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/5ac374c3e295c8b917208ff41b4d30f76668478c",
-                "reference": "5ac374c3e295c8b917208ff41b4d30f76668478c",
+                "url": "https://api.github.com/repos/Spomky-Labs/pki-framework/zipball/eced5b5ce70518b983ff2be486e902bbd15135ae",
+                "reference": "eced5b5ce70518b983ff2be486e902bbd15135ae",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.10|^0.11|^0.12",
+                "brick/math": "^0.10|^0.11|^0.12|^0.13",
                 "ext-mbstring": "*",
                 "php": ">=8.1"
             },
@@ -22334,7 +22650,7 @@
                 "phpstan/phpstan-deprecation-rules": "^1.0|^2.0",
                 "phpstan/phpstan-phpunit": "^1.1|^2.0",
                 "phpstan/phpstan-strict-rules": "^1.3|^2.0",
-                "phpunit/phpunit": "^10.1|^11.0",
+                "phpunit/phpunit": "^10.1|^11.0|^12.0",
                 "rector/rector": "^1.0|^2.0",
                 "roave/security-advisories": "dev-latest",
                 "symfony/string": "^6.4|^7.0",
@@ -22399,7 +22715,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Spomky-Labs/pki-framework/issues",
-                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.2.2"
+                "source": "https://github.com/Spomky-Labs/pki-framework/tree/1.3.0"
             },
             "funding": [
                 {
@@ -22411,11 +22727,11 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2025-01-03T09:35:48+00:00"
+            "time": "2025-06-13T08:35:04+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
@@ -22469,7 +22785,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.2.0"
+                "source": "https://github.com/symfony/clock/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -22489,34 +22805,34 @@
         },
         {
             "name": "symfony/config",
-            "version": "v6.4.14",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "4e55e7e4ffddd343671ea972216d4509f46c22ef"
+                "reference": "ba62ae565f1327c2f6366726312ed828c85853bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/4e55e7e4ffddd343671ea972216d4509f46c22ef",
-                "reference": "4e55e7e4ffddd343671ea972216d4509f46c22ef",
+                "url": "https://api.github.com/repos/symfony/config/zipball/ba62ae565f1327c2f6366726312ed828c85853bc",
+                "reference": "ba62ae565f1327c2f6366726312ed828c85853bc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/filesystem": "^5.4|^6.0|^7.0",
+                "symfony/filesystem": "^7.1",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "symfony/finder": "<5.4",
+                "symfony/finder": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
-                "symfony/finder": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
+                "symfony/event-dispatcher": "^6.4|^7.0",
+                "symfony/finder": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/yaml": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -22544,7 +22860,7 @@
             "description": "Helps you find, load, combine, autofill and validate configuration values of any kind",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/config/tree/v6.4.14"
+                "source": "https://github.com/symfony/config/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -22560,20 +22876,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-04T11:33:53+00:00"
+            "time": "2025-05-15T09:04:05+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v6.4.17",
+            "version": "v6.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04"
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/799445db3f15768ecc382ac5699e6da0520a0a04",
-                "reference": "799445db3f15768ecc382ac5699e6da0520a0a04",
+                "url": "https://api.github.com/repos/symfony/console/zipball/9056771b8eca08d026cd3280deeec3cfd99c4d93",
+                "reference": "9056771b8eca08d026cd3280deeec3cfd99c4d93",
                 "shasum": ""
             },
             "require": {
@@ -22638,7 +22954,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.4.17"
+                "source": "https://github.com/symfony/console/tree/v6.4.23"
             },
             "funding": [
                 {
@@ -22654,11 +22970,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-07T12:07:30+00:00"
+            "time": "2025-06-27T19:37:22+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -22703,7 +23019,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.2.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -22723,40 +23039,39 @@
         },
         {
             "name": "symfony/dependency-injection",
-            "version": "v6.4.19",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "b343c3b2f1539fe41331657b37d5c96c1d1ea842"
+                "reference": "8656c4848b48784c4bb8c4ae50d2b43f832cead8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/b343c3b2f1539fe41331657b37d5c96c1d1ea842",
-                "reference": "b343c3b2f1539fe41331657b37d5c96c1d1ea842",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/8656c4848b48784c4bb8c4ae50d2b43f832cead8",
+                "reference": "8656c4848b48784c4bb8c4ae50d2b43f832cead8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "psr/container": "^1.1|^2.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/service-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.2.10|^7.0"
+                "symfony/service-contracts": "^3.5",
+                "symfony/var-exporter": "^6.4.20|^7.2.5"
             },
             "conflict": {
                 "ext-psr": "<1.1|>=2",
-                "symfony/config": "<6.1",
-                "symfony/finder": "<5.4",
-                "symfony/proxy-manager-bridge": "<6.3",
-                "symfony/yaml": "<5.4"
+                "symfony/config": "<6.4",
+                "symfony/finder": "<6.4",
+                "symfony/yaml": "<6.4"
             },
             "provide": {
                 "psr/container-implementation": "1.1|2.0",
                 "symfony/service-implementation": "1.1|2.0|3.0"
             },
             "require-dev": {
-                "symfony/config": "^6.1|^7.0",
-                "symfony/expression-language": "^5.4|^6.0|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/config": "^6.4|^7.0",
+                "symfony/expression-language": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -22784,7 +23099,7 @@
             "description": "Allows you to standardize and centralize the way objects are constructed in your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/dependency-injection/tree/v6.4.19"
+                "source": "https://github.com/symfony/dependency-injection/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -22800,20 +23115,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-20T10:02:49+00:00"
+            "time": "2025-06-24T04:04:43+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
                 "shasum": ""
             },
             "require": {
@@ -22826,7 +23141,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -22851,7 +23166,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -22867,20 +23182,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.2.4",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "aabf79938aa795350c07ce6464dd1985607d95d5"
+                "reference": "35b55b166f6752d6aaf21aa042fc5ed280fce235"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/aabf79938aa795350c07ce6464dd1985607d95d5",
-                "reference": "aabf79938aa795350c07ce6464dd1985607d95d5",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/35b55b166f6752d6aaf21aa042fc5ed280fce235",
+                "reference": "35b55b166f6752d6aaf21aa042fc5ed280fce235",
                 "shasum": ""
             },
             "require": {
@@ -22893,9 +23208,11 @@
                 "symfony/http-kernel": "<6.4"
             },
             "require-dev": {
+                "symfony/console": "^6.4|^7.0",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0"
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/webpack-encore-bundle": "^1.0|^2.0"
             },
             "bin": [
                 "Resources/bin/patch-type-declarations"
@@ -22926,7 +23243,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.2.4"
+                "source": "https://github.com/symfony/error-handler/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -22942,20 +23259,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-02T20:27:07+00:00"
+            "time": "2025-06-13T07:48:40+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1"
+                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/910c5db85a5356d0fea57680defec4e99eb9c8c1",
-                "reference": "910c5db85a5356d0fea57680defec4e99eb9c8c1",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/497f73ac996a598c92409b44ac43b6690c4f666d",
+                "reference": "497f73ac996a598c92409b44ac43b6690c4f666d",
                 "shasum": ""
             },
             "require": {
@@ -23006,7 +23323,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.2.0"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -23022,20 +23339,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2025-04-22T09:11:45+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f"
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7642f5e970b672283b7823222ae8ef8bbc160b9f",
-                "reference": "7642f5e970b672283b7823222ae8ef8bbc160b9f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
+                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
                 "shasum": ""
             },
             "require": {
@@ -23049,7 +23366,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -23082,7 +23399,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -23098,11 +23415,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-25T14:21:43+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v7.2.0",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
@@ -23148,7 +23465,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v7.2.0"
+                "source": "https://github.com/symfony/filesystem/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -23168,16 +23485,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.2.2",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb"
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/87a71856f2f56e4100373e92529eed3171695cfb",
-                "reference": "87a71856f2f56e4100373e92529eed3171695cfb",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/ec2344cf77a48253bbca6939aa3d2477773ea63d",
+                "reference": "ec2344cf77a48253bbca6939aa3d2477773ea63d",
                 "shasum": ""
             },
             "require": {
@@ -23212,7 +23529,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.2.2"
+                "source": "https://github.com/symfony/finder/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -23228,20 +23545,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-30T19:00:17+00:00"
+            "time": "2024-12-30T19:00:26+00:00"
         },
         {
             "name": "symfony/http-client",
-            "version": "v7.2.4",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client.git",
-                "reference": "78981a2ffef6437ed92d4d7e2a86a82f256c6dc6"
+                "reference": "4403d87a2c16f33345dca93407a8714ee8c05a64"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client/zipball/78981a2ffef6437ed92d4d7e2a86a82f256c6dc6",
-                "reference": "78981a2ffef6437ed92d4d7e2a86a82f256c6dc6",
+                "url": "https://api.github.com/repos/symfony/http-client/zipball/4403d87a2c16f33345dca93407a8714ee8c05a64",
+                "reference": "4403d87a2c16f33345dca93407a8714ee8c05a64",
                 "shasum": ""
             },
             "require": {
@@ -23253,6 +23570,7 @@
             },
             "conflict": {
                 "amphp/amp": "<2.5",
+                "amphp/socket": "<1.1",
                 "php-http/discovery": "<1.15",
                 "symfony/http-foundation": "<6.4"
             },
@@ -23265,7 +23583,6 @@
             "require-dev": {
                 "amphp/http-client": "^4.2.1|^5.0",
                 "amphp/http-tunnel": "^1.0|^2.0",
-                "amphp/socket": "^1.1",
                 "guzzlehttp/promises": "^1.4|^2.0",
                 "nyholm/psr7": "^1.0",
                 "php-http/httplug": "^1.0|^2.0",
@@ -23307,7 +23624,7 @@
                 "http"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client/tree/v7.2.4"
+                "source": "https://github.com/symfony/http-client/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -23323,20 +23640,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T10:27:23+00:00"
+            "time": "2025-06-28T07:58:39+00:00"
         },
         {
             "name": "symfony/http-client-contracts",
-            "version": "v3.5.2",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-client-contracts.git",
-                "reference": "ee8d807ab20fcb51267fdace50fbe3494c31e645"
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/ee8d807ab20fcb51267fdace50fbe3494c31e645",
-                "reference": "ee8d807ab20fcb51267fdace50fbe3494c31e645",
+                "url": "https://api.github.com/repos/symfony/http-client-contracts/zipball/75d7043853a42837e68111812f4d964b01e5101c",
+                "reference": "75d7043853a42837e68111812f4d964b01e5101c",
                 "shasum": ""
             },
             "require": {
@@ -23349,7 +23666,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -23385,7 +23702,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/http-client-contracts/tree/v3.5.2"
+                "source": "https://github.com/symfony/http-client-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -23401,20 +23718,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-07T08:49:48+00:00"
+            "time": "2025-04-29T11:18:49+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.2.3",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "ee1b504b8926198be89d05e5b6fc4c3810c090f0"
+                "reference": "23dd60256610c86a3414575b70c596e5deff6ed9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/ee1b504b8926198be89d05e5b6fc4c3810c090f0",
-                "reference": "ee1b504b8926198be89d05e5b6fc4c3810c090f0",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/23dd60256610c86a3414575b70c596e5deff6ed9",
+                "reference": "23dd60256610c86a3414575b70c596e5deff6ed9",
                 "shasum": ""
             },
             "require": {
@@ -23431,6 +23748,7 @@
                 "doctrine/dbal": "^3.6|^4",
                 "predis/predis": "^1.1|^2.0",
                 "symfony/cache": "^6.4.12|^7.1.5",
+                "symfony/clock": "^6.4|^7.0",
                 "symfony/dependency-injection": "^6.4|^7.0",
                 "symfony/expression-language": "^6.4|^7.0",
                 "symfony/http-kernel": "^6.4|^7.0",
@@ -23463,7 +23781,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.2.3"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -23479,20 +23797,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T10:56:55+00:00"
+            "time": "2025-06-23T15:07:14+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.2.4",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "9f1103734c5789798fefb90e91de4586039003ed"
+                "reference": "1644879a66e4aa29c36fe33dfa6c54b450ce1831"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/9f1103734c5789798fefb90e91de4586039003ed",
-                "reference": "9f1103734c5789798fefb90e91de4586039003ed",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/1644879a66e4aa29c36fe33dfa6c54b450ce1831",
+                "reference": "1644879a66e4aa29c36fe33dfa6c54b450ce1831",
                 "shasum": ""
             },
             "require": {
@@ -23500,8 +23818,8 @@
                 "psr/log": "^1|^2|^3",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/error-handler": "^6.4|^7.0",
-                "symfony/event-dispatcher": "^6.4|^7.0",
-                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/event-dispatcher": "^7.3",
+                "symfony/http-foundation": "^7.3",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -23577,7 +23895,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.2.4"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -23593,20 +23911,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-26T11:01:22+00:00"
+            "time": "2025-06-28T08:24:55+00:00"
         },
         {
             "name": "symfony/intl",
-            "version": "v6.4.15",
+            "version": "v6.4.23",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/intl.git",
-                "reference": "b1d5e8d82615b60f229216edfee0b59e2ef66da6"
+                "reference": "a3b12ce29a770d1f26c380dabf56a71bc2a88c84"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/intl/zipball/b1d5e8d82615b60f229216edfee0b59e2ef66da6",
-                "reference": "b1d5e8d82615b60f229216edfee0b59e2ef66da6",
+                "url": "https://api.github.com/repos/symfony/intl/zipball/a3b12ce29a770d1f26c380dabf56a71bc2a88c84",
+                "reference": "a3b12ce29a770d1f26c380dabf56a71bc2a88c84",
                 "shasum": ""
             },
             "require": {
@@ -23660,7 +23978,7 @@
                 "localization"
             ],
             "support": {
-                "source": "https://github.com/symfony/intl/tree/v6.4.15"
+                "source": "https://github.com/symfony/intl/tree/v6.4.23"
             },
             "funding": [
                 {
@@ -23676,11 +23994,176 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-08T15:28:48+00:00"
+            "time": "2025-06-06T07:42:46+00:00"
+        },
+        {
+            "name": "symfony/mailer",
+            "version": "v6.4.23",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mailer.git",
+                "reference": "a480322ddf8e54de262c9bca31fdcbe26b553de5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/a480322ddf8e54de262c9bca31fdcbe26b553de5",
+                "reference": "a480322ddf8e54de262c9bca31fdcbe26b553de5",
+                "shasum": ""
+            },
+            "require": {
+                "egulias/email-validator": "^2.1.10|^3|^4",
+                "php": ">=8.1",
+                "psr/event-dispatcher": "^1",
+                "psr/log": "^1|^2|^3",
+                "symfony/event-dispatcher": "^5.4|^6.0|^7.0",
+                "symfony/mime": "^6.2|^7.0",
+                "symfony/service-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "symfony/http-client-contracts": "<2.5",
+                "symfony/http-kernel": "<5.4",
+                "symfony/messenger": "<6.2",
+                "symfony/mime": "<6.2",
+                "symfony/twig-bridge": "<6.2.1"
+            },
+            "require-dev": {
+                "symfony/console": "^5.4|^6.0|^7.0",
+                "symfony/http-client": "^5.4|^6.0|^7.0",
+                "symfony/messenger": "^6.2|^7.0",
+                "symfony/twig-bridge": "^6.2|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mailer\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Helps sending emails",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/mailer/tree/v6.4.23"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-06-26T21:24:02+00:00"
+        },
+        {
+            "name": "symfony/mime",
+            "version": "v6.4.21",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/mime.git",
+                "reference": "fec8aa5231f3904754955fad33c2db50594d22d1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/fec8aa5231f3904754955fad33c2db50594d22d1",
+                "reference": "fec8aa5231f3904754955fad33c2db50594d22d1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-intl-idn": "^1.10",
+                "symfony/polyfill-mbstring": "^1.0"
+            },
+            "conflict": {
+                "egulias/email-validator": "~3.0.0",
+                "phpdocumentor/reflection-docblock": "<3.2.2",
+                "phpdocumentor/type-resolver": "<1.4.0",
+                "symfony/mailer": "<5.4",
+                "symfony/serializer": "<6.4.3|>7.0,<7.0.3"
+            },
+            "require-dev": {
+                "egulias/email-validator": "^2.1.10|^3.1|^4",
+                "league/html-to-markdown": "^5.0",
+                "phpdocumentor/reflection-docblock": "^3.0|^4.0|^5.0",
+                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
+                "symfony/process": "^5.4|^6.4|^7.0",
+                "symfony/property-access": "^5.4|^6.0|^7.0",
+                "symfony/property-info": "^5.4|^6.0|^7.0",
+                "symfony/serializer": "^6.4.3|^7.0.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Mime\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows manipulating MIME messages",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "mime",
+                "mime-type"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/mime/tree/v6.4.21"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-04-27T13:27:38+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -23739,7 +24222,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -23759,7 +24242,7 @@
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
@@ -23817,7 +24300,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -23837,16 +24320,16 @@
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "c36586dcf89a12315939e00ec9b4474adcb1d773"
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/c36586dcf89a12315939e00ec9b4474adcb1d773",
-                "reference": "c36586dcf89a12315939e00ec9b4474adcb1d773",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
                 "shasum": ""
             },
             "require": {
@@ -23900,7 +24383,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -23916,11 +24399,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-09-10T14:38:51+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
@@ -23981,7 +24464,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24001,19 +24484,20 @@
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
-                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
                 "shasum": ""
             },
             "require": {
+                "ext-iconv": "*",
                 "php": ">=7.2"
             },
             "provide": {
@@ -24061,7 +24545,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24077,11 +24561,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2024-12-23T08:48:59+00:00"
         },
         {
             "name": "symfony/polyfill-php73",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php73.git",
@@ -24137,7 +24621,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24157,16 +24641,16 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
-                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
                 "shasum": ""
             },
             "require": {
@@ -24217,7 +24701,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24233,11 +24717,11 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2025-01-02T08:10:11+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
@@ -24293,7 +24777,83 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.32.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php82",
+            "version": "v1.32.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php82.git",
+                "reference": "5d2ed36f7734637dacc025f179698031951b1692"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php82/zipball/5d2ed36f7734637dacc025f179698031951b1692",
+                "reference": "5d2ed36f7734637dacc025f179698031951b1692",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/symfony/polyfill",
+                    "name": "symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php82\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 8.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php82/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24313,7 +24873,7 @@
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.31.0",
+            "version": "v1.32.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
@@ -24369,7 +24929,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.31.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.32.0"
             },
             "funding": [
                 {
@@ -24389,16 +24949,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v6.4.19",
+            "version": "v6.4.20",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3"
+                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3",
-                "reference": "7a1c12e87b08ec9c97abdd188c9b3f5a40e37fc3",
+                "url": "https://api.github.com/repos/symfony/process/zipball/e2a61c16af36c9a07e5c9906498b73e091949a20",
+                "reference": "e2a61c16af36c9a07e5c9906498b73e091949a20",
                 "shasum": ""
             },
             "require": {
@@ -24430,7 +24990,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v6.4.19"
+                "source": "https://github.com/symfony/process/tree/v6.4.20"
             },
             "funding": [
                 {
@@ -24446,7 +25006,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-04T13:35:48+00:00"
+            "time": "2025-03-10T17:11:00+00:00"
         },
         {
             "name": "symfony/proxy-manager-bridge",
@@ -24517,57 +25077,57 @@
         },
         {
             "name": "symfony/serializer",
-            "version": "v6.4.19",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/serializer.git",
-                "reference": "a221b2f6066af304d760cff7a26f201b4fab4aef"
+                "reference": "feaf837cedbbc8287986602223175d3fd639922d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/serializer/zipball/a221b2f6066af304d760cff7a26f201b4fab4aef",
-                "reference": "a221b2f6066af304d760cff7a26f201b4fab4aef",
+                "url": "https://api.github.com/repos/symfony/serializer/zipball/feaf837cedbbc8287986602223175d3fd639922d",
+                "reference": "feaf837cedbbc8287986602223175d3fd639922d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.2",
                 "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-ctype": "~1.8"
             },
             "conflict": {
-                "doctrine/annotations": "<1.12",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/dependency-injection": "<5.4",
-                "symfony/property-access": "<5.4",
-                "symfony/property-info": "<5.4.24|>=6,<6.2.11",
-                "symfony/uid": "<5.4",
+                "symfony/dependency-injection": "<6.4",
+                "symfony/property-access": "<6.4",
+                "symfony/property-info": "<6.4",
+                "symfony/uid": "<6.4",
                 "symfony/validator": "<6.4",
-                "symfony/yaml": "<5.4"
+                "symfony/yaml": "<6.4"
             },
             "require-dev": {
-                "doctrine/annotations": "^1.12|^2",
                 "phpdocumentor/reflection-docblock": "^3.2|^4.0|^5.0",
+                "phpstan/phpdoc-parser": "^1.0|^2.0",
                 "seld/jsonlint": "^1.10",
-                "symfony/cache": "^5.4|^6.0|^7.0",
-                "symfony/config": "^5.4|^6.0|^7.0",
-                "symfony/console": "^5.4|^6.0|^7.0",
-                "symfony/dependency-injection": "^5.4|^6.0|^7.0",
-                "symfony/error-handler": "^5.4|^6.0|^7.0",
-                "symfony/filesystem": "^5.4|^6.0|^7.0",
-                "symfony/form": "^5.4|^6.0|^7.0",
-                "symfony/http-foundation": "^5.4|^6.0|^7.0",
-                "symfony/http-kernel": "^5.4|^6.0|^7.0",
-                "symfony/messenger": "^5.4|^6.0|^7.0",
-                "symfony/mime": "^5.4|^6.0|^7.0",
-                "symfony/property-access": "^5.4.26|^6.3|^7.0",
-                "symfony/property-info": "^5.4.24|^6.2.11|^7.0",
+                "symfony/cache": "^6.4|^7.0",
+                "symfony/config": "^6.4|^7.0",
+                "symfony/console": "^6.4|^7.0",
+                "symfony/dependency-injection": "^7.2",
+                "symfony/error-handler": "^6.4|^7.0",
+                "symfony/filesystem": "^6.4|^7.0",
+                "symfony/form": "^6.4|^7.0",
+                "symfony/http-foundation": "^6.4|^7.0",
+                "symfony/http-kernel": "^6.4|^7.0",
+                "symfony/messenger": "^6.4|^7.0",
+                "symfony/mime": "^6.4|^7.0",
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/property-info": "^6.4|^7.0",
                 "symfony/translation-contracts": "^2.5|^3",
-                "symfony/uid": "^5.4|^6.0|^7.0",
+                "symfony/type-info": "^7.1",
+                "symfony/uid": "^6.4|^7.0",
                 "symfony/validator": "^6.4|^7.0",
-                "symfony/var-dumper": "^5.4|^6.0|^7.0",
-                "symfony/var-exporter": "^5.4|^6.0|^7.0",
-                "symfony/yaml": "^5.4|^6.0|^7.0"
+                "symfony/var-dumper": "^6.4|^7.0",
+                "symfony/var-exporter": "^6.4|^7.0",
+                "symfony/yaml": "^6.4|^7.0"
             },
             "type": "library",
             "autoload": {
@@ -24595,7 +25155,7 @@
             "description": "Handles serializing and deserializing data structures, including object graphs, into array structures or other formats like XML and JSON.",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/serializer/tree/v6.4.19"
+                "source": "https://github.com/symfony/serializer/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -24611,20 +25171,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-24T08:42:36+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
+                "reference": "f021b05a130d35510bd6b25fe9053c2a8a15d5d4",
                 "shasum": ""
             },
             "require": {
@@ -24642,7 +25202,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -24678,7 +25238,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -24694,20 +25254,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2025-04-25T09:37:31+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.15",
+            "version": "v6.4.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f"
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
-                "reference": "73a5e66ea2e1677c98d4449177c5a9cf9d8b4c6f",
+                "url": "https://api.github.com/repos/symfony/string/zipball/73e2c6966a5aef1d4892873ed5322245295370c6",
+                "reference": "73e2c6966a5aef1d4892873ed5322245295370c6",
                 "shasum": ""
             },
             "require": {
@@ -24764,7 +25324,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.15"
+                "source": "https://github.com/symfony/string/tree/v6.4.21"
             },
             "funding": [
                 {
@@ -24780,20 +25340,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-13T13:31:12+00:00"
+            "time": "2025-04-18T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.2.4",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "283856e6981286cc0d800b53bd5703e8e363f05a"
+                "reference": "241d5ac4910d256660238a7ecf250deba4c73063"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/283856e6981286cc0d800b53bd5703e8e363f05a",
-                "reference": "283856e6981286cc0d800b53bd5703e8e363f05a",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/241d5ac4910d256660238a7ecf250deba4c73063",
+                "reference": "241d5ac4910d256660238a7ecf250deba4c73063",
                 "shasum": ""
             },
             "require": {
@@ -24803,6 +25363,7 @@
                 "symfony/translation-contracts": "^2.5|^3.0"
             },
             "conflict": {
+                "nikic/php-parser": "<5.0",
                 "symfony/config": "<6.4",
                 "symfony/console": "<6.4",
                 "symfony/dependency-injection": "<6.4",
@@ -24816,7 +25377,7 @@
                 "symfony/translation-implementation": "2.3|3.0"
             },
             "require-dev": {
-                "nikic/php-parser": "^4.18|^5.0",
+                "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
                 "symfony/config": "^6.4|^7.0",
                 "symfony/console": "^6.4|^7.0",
@@ -24859,7 +25420,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.2.4"
+                "source": "https://github.com/symfony/translation/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -24875,20 +25436,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T10:27:23+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.5.1",
+            "version": "v3.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c"
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/4667ff3bd513750603a09c8dedbea942487fb07c",
-                "reference": "4667ff3bd513750603a09c8dedbea942487fb07c",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
+                "reference": "df210c7a2573f1913b2d17cc95f90f53a73d8f7d",
                 "shasum": ""
             },
             "require": {
@@ -24901,7 +25462,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.5-dev"
+                    "dev-main": "3.6-dev"
                 }
             },
             "autoload": {
@@ -24937,7 +25498,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.5.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.0"
             },
             "funding": [
                 {
@@ -24953,24 +25514,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:20:29+00:00"
+            "time": "2024-09-27T08:32:26+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.2.3",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a"
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/82b478c69745d8878eb60f9a049a4d584996f73a",
-                "reference": "82b478c69745d8878eb60f9a049a4d584996f73a",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
+                "reference": "6e209fbe5f5a7b6043baba46fe5735a4b85d0d42",
                 "shasum": ""
             },
             "require": {
                 "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
@@ -25020,7 +25582,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.2.3"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -25036,24 +25598,25 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-17T11:39:41+00:00"
+            "time": "2025-06-27T19:55:54+00:00"
         },
         {
             "name": "symfony/var-exporter",
-            "version": "v7.2.4",
+            "version": "v7.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "4ede73aa7a73d81506002d2caadbbdad1ef5b69a"
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/4ede73aa7a73d81506002d2caadbbdad1ef5b69a",
-                "reference": "4ede73aa7a73d81506002d2caadbbdad1ef5b69a",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/c9a1168891b5aaadfd6332ef44393330b3498c4c",
+                "reference": "c9a1168891b5aaadfd6332ef44393330b3498c4c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3"
             },
             "require-dev": {
                 "symfony/property-access": "^6.4|^7.0",
@@ -25096,7 +25659,7 @@
                 "serialize"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.4"
+                "source": "https://github.com/symfony/var-exporter/tree/v7.3.0"
             },
             "funding": [
                 {
@@ -25112,32 +25675,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-02-13T10:27:23+00:00"
+            "time": "2025-05-15T09:04:05+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.4.18",
+            "version": "v7.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5"
+                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
-                "reference": "bf598c9d9bb4a22f495a4e26e4c4fce2f8ecefc5",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/0c3555045a46ab3cd4cc5a69d161225195230edb",
+                "reference": "0c3555045a46ab3cd4cc5a69d161225195230edb",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
-                "symfony/console": "<5.4"
+                "symfony/console": "<6.4"
             },
             "require-dev": {
-                "symfony/console": "^5.4|^6.0|^7.0"
+                "symfony/console": "^6.4|^7.0"
             },
             "bin": [
                 "Resources/bin/yaml-lint"
@@ -25168,7 +25731,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.4.18"
+                "source": "https://github.com/symfony/yaml/tree/v7.3.1"
             },
             "funding": [
                 {
@@ -25184,7 +25747,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-07T09:44:41+00:00"
+            "time": "2025-06-03T06:57:57+00:00"
         },
         {
             "name": "tedivm/jshrink",
@@ -25305,16 +25868,16 @@
         },
         {
             "name": "web-token/jwt-framework",
-            "version": "3.4.7",
+            "version": "3.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/web-token/jwt-framework.git",
-                "reference": "d7ba8efd5bfab0ef88af600a2a69e5e1e75e8f68"
+                "reference": "788267095b0b0c3ba42559eb2ec955f416628ec0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/web-token/jwt-framework/zipball/d7ba8efd5bfab0ef88af600a2a69e5e1e75e8f68",
-                "reference": "d7ba8efd5bfab0ef88af600a2a69e5e1e75e8f68",
+                "url": "https://api.github.com/repos/web-token/jwt-framework/zipball/788267095b0b0c3ba42559eb2ec955f416628ec0",
+                "reference": "788267095b0b0c3ba42559eb2ec955f416628ec0",
                 "shasum": ""
             },
             "require": {
@@ -25326,7 +25889,7 @@
                 "paragonie/constant_time_encoding": "^2.6|^3.0",
                 "paragonie/sodium_compat": "^1.20|^2.0",
                 "php": ">=8.1",
-                "psr/cache": "^3.0",
+                "psr/cache": "^2.0|^3.0",
                 "psr/clock": "^1.0",
                 "psr/event-dispatcher": "^1.0",
                 "psr/http-client": "^1.0",
@@ -25458,7 +26021,7 @@
             ],
             "support": {
                 "issues": "https://github.com/web-token/jwt-framework/issues",
-                "source": "https://github.com/web-token/jwt-framework/tree/3.4.7"
+                "source": "https://github.com/web-token/jwt-framework/tree/3.4.8"
             },
             "funding": [
                 {
@@ -25470,7 +26033,7 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2024-12-12T18:06:31+00:00"
+            "time": "2025-05-07T09:11:18+00:00"
         },
         {
             "name": "webimpress/safe-writer",
@@ -25532,75 +26095,17 @@
             "time": "2021-04-19T16:34:45+00:00"
         },
         {
-            "name": "webmozart/assert",
-            "version": "1.11.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "reference": "11cb2199493b2f8a3b53e7f19068fc6aac760991",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "conflict": {
-                "phpstan/phpstan": "<0.12.20",
-                "vimeo/psalm": "<4.6.1 || 4.6.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^8.5.13"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.11.0"
-            },
-            "time": "2022-06-03T18:03:27+00:00"
-        },
-        {
             "name": "webonyx/graphql-php",
-            "version": "v15.19.1",
+            "version": "v15.21.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webonyx/graphql-php.git",
-                "reference": "fa01712b1a170ddc1d92047011b2f4c2bdfa8234"
+                "reference": "1a7aac3b7f8d66fd52aa7d1b7eafad3dec1f9cb5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/fa01712b1a170ddc1d92047011b2f4c2bdfa8234",
-                "reference": "fa01712b1a170ddc1d92047011b2f4c2bdfa8234",
+                "url": "https://api.github.com/repos/webonyx/graphql-php/zipball/1a7aac3b7f8d66fd52aa7d1b7eafad3dec1f9cb5",
+                "reference": "1a7aac3b7f8d66fd52aa7d1b7eafad3dec1f9cb5",
                 "shasum": ""
             },
             "require": {
@@ -25613,22 +26118,22 @@
                 "amphp/http-server": "^2.1",
                 "dms/phpunit-arraysubset-asserts": "dev-master",
                 "ergebnis/composer-normalize": "^2.28",
-                "friendsofphp/php-cs-fixer": "3.65.0",
-                "mll-lab/php-cs-fixer-config": "^5.9.2",
+                "friendsofphp/php-cs-fixer": "3.82.2",
+                "mll-lab/php-cs-fixer-config": "5.11.0",
                 "nyholm/psr7": "^1.5",
                 "phpbench/phpbench": "^1.2",
                 "phpstan/extension-installer": "^1.1",
-                "phpstan/phpstan": "1.12.12",
-                "phpstan/phpstan-phpunit": "1.4.1",
-                "phpstan/phpstan-strict-rules": "1.6.1",
+                "phpstan/phpstan": "2.1.17",
+                "phpstan/phpstan-phpunit": "2.0.6",
+                "phpstan/phpstan-strict-rules": "2.0.4",
                 "phpunit/phpunit": "^9.5 || ^10.5.21 || ^11",
                 "psr/http-message": "^1 || ^2",
                 "react/http": "^1.6",
                 "react/promise": "^2.0 || ^3.0",
-                "rector/rector": "^1.0",
+                "rector/rector": "^2.0",
                 "symfony/polyfill-php81": "^1.23",
                 "symfony/var-exporter": "^5 || ^6 || ^7",
-                "thecodingmachine/safe": "^1.3 || ^2"
+                "thecodingmachine/safe": "^1.3 || ^2 || ^3"
             },
             "suggest": {
                 "amphp/http-server": "To leverage async resolving with webserver on AMPHP platform",
@@ -25653,7 +26158,7 @@
             ],
             "support": {
                 "issues": "https://github.com/webonyx/graphql-php/issues",
-                "source": "https://github.com/webonyx/graphql-php/tree/v15.19.1"
+                "source": "https://github.com/webonyx/graphql-php/tree/v15.21.2"
             },
             "funding": [
                 {
@@ -25661,32 +26166,32 @@
                     "type": "open_collective"
                 }
             ],
-            "time": "2024-12-19T10:52:18+00:00"
+            "time": "2025-07-10T08:58:25+00:00"
         },
         {
             "name": "wikimedia/less.php",
-            "version": "v3.2.1",
+            "version": "v5.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wikimedia/less.php.git",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559"
+                "reference": "75a0db4a7698b5fe668af553329605ac40f374af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/0d5b30ba792bdbf8991a646fc9c30561b38a5559",
-                "reference": "0d5b30ba792bdbf8991a646fc9c30561b38a5559",
+                "url": "https://api.github.com/repos/wikimedia/less.php/zipball/75a0db4a7698b5fe668af553329605ac40f374af",
+                "reference": "75a0db4a7698b5fe668af553329605ac40f374af",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.9"
+                "php": ">=8.1"
             },
             "require-dev": {
-                "mediawiki/mediawiki-codesniffer": "40.0.1",
-                "mediawiki/mediawiki-phan-config": "0.12.0",
-                "mediawiki/minus-x": "1.1.1",
+                "mediawiki/mediawiki-codesniffer": "47.0.0",
+                "mediawiki/mediawiki-phan-config": "0.15.1",
+                "mediawiki/minus-x": "1.1.3",
                 "php-parallel-lint/php-console-highlighter": "1.0.0",
-                "php-parallel-lint/php-parallel-lint": "1.3.2",
-                "phpunit/phpunit": "^8.5"
+                "php-parallel-lint/php-parallel-lint": "1.4.0",
+                "phpunit/phpunit": "9.6.21"
             },
             "bin": [
                 "bin/lessc"
@@ -25734,9 +26239,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wikimedia/less.php/issues",
-                "source": "https://github.com/wikimedia/less.php/tree/v3.2.1"
+                "source": "https://github.com/wikimedia/less.php/tree/v5.4.0"
             },
-            "time": "2023-02-03T06:43:41+00:00"
+            "time": "2025-07-03T20:27:02+00:00"
         },
         {
             "name": "zordius/lightncandy",


### PR DESCRIPTION
## Description
- replaces patch ACSD-58739 with ACP2E-3705 per https://github.com/magento/quality-patches/blob/master/support-patches.json#L12306-L12315
- adds php-http/discovery to allowed plugins
- Updates composer.lock

## Related Issue
Closes #21 
Closes #20 


